### PR TITLE
Hotfix: add OTHER type to medium table

### DIFF
--- a/migrations/Postgres/1669300081552_insert_into_public_medium/down.sql
+++ b/migrations/Postgres/1669300081552_insert_into_public_medium/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."medium" WHERE "name" = 'other';

--- a/migrations/Postgres/1669300081552_insert_into_public_medium/up.sql
+++ b/migrations/Postgres/1669300081552_insert_into_public_medium/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."medium"("name", "description") VALUES (E'other', E'Other');


### PR DESCRIPTION
This adds a migration to add the missing OTHER enum to the medium table