### PR TITLE
fix(journal): properly validate required fields

### DIFF
--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -69,6 +69,7 @@ type Action =
   | { type: "set_content"; content: string }
   | { type: "set_time"; time: Date | undefined }
   | { type: "save" }
+  | { type: "save_error" }
   | { type: "set_media_detail"; detail: MediaDetail }
   | { type: "set_autofill_details"; detail: AutofillDetail };
 type Dispatch = (action: Action) => void;
@@ -109,6 +110,9 @@ function Editor() {
       // reset the form values
       dispatch({ type: "clear" });
     },
+    onError() {
+      dispatch({ type: "save_error" });
+    },
     refetchQueries: [{ query: GetJournalMessages, variables: { journalId: journalId } }],
   });
 
@@ -117,6 +121,9 @@ function Editor() {
       // reset the form values
       dispatch({ type: "clear" });
     },
+    onError() {
+      dispatch({ type: "save_error" });
+    },
     refetchQueries: [{ query: GetJournalMessages, variables: { journalId: journalId } }],
   });
 
@@ -124,6 +131,9 @@ function Editor() {
     switch (action.type) {
       case "save": {
         return Object.assign({}, state, { saving: true });
+      }
+      case "save_error": {
+        return Object.assign({}, state, { saving: false });
       }
       case "set_sender": {
         return Object.assign({}, state, { sender: action.sender });

--- a/ui/src/views/journal/EditorForms/Elements.tsx
+++ b/ui/src/views/journal/EditorForms/Elements.tsx
@@ -164,7 +164,7 @@ const RadioChannelDetailInput = () => {
 };
 
 const SaveButton = () => {
-  const { dispatch } = useEditorContext();
+  const { state, dispatch } = useEditorContext();
   return (
     <div className="control">
       <button
@@ -173,6 +173,7 @@ const SaveButton = () => {
           e.preventDefault();
           dispatch({ type: "save" });
         }}
+        disabled={state.content === "" || state.sender === "" || state.receiver === ""}
       >
         {t("save")}
       </button>


### PR DESCRIPTION
Details:
* properly reset the saving state in the editor on errors, otherwise the message will be saved as soon as a single char is added to the last remaining field if saving has been attempted before
* disable the save button as long as not all fields are filled out

![image](https://github.com/user-attachments/assets/f37e6952-da80-4c10-838a-bfb107318817)
