### PR TITLE
fix(ui): text color and in footer changed to be adaptive

### DIFF
--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -8,26 +8,28 @@ function Footer() {
     <footer className="footer is-hidden-print">
       <div className="content has-text-centered is-flex is-align-content-space-around is-align-items-center is-justify-content-center">
         <a
-          className="has-text-grey-light"
+          className="has-text-current"
           href="https://github.com/f-eld-ch/sitrep"
           target="_blank"
           rel="noopener noreferrer"
         >
-          <span className="icon-text is-small has-text-black">
+          <span className="icon-text is-small is-size-7">
             <span className="icon is-align-content-center">
               <FontAwesomeIcon icon={faGithub} />
             </span>
             <span>
-              <p className="has-text-dark">SitRep</p>
+              <strong>
+                <p className="is-size-7 is-family-monospace has-text-current">SitRep</p>
+              </strong>
             </span>
           </span>
         </a>
 
-        <p className="is-size-7 is-family-monospace ml-1">
-          made with <FontAwesomeIcon icon={faHeart} color="red" /> in Switzerland by{" "}
-          <strong>
-            <a className="has-text-dark" href="https://github.com/f-eld-ch" target="_blank" rel="noopener noreferrer">
-              F-ELD
+        <p className="is-size-7 is-family-monospace ml-2">
+          made with <FontAwesomeIcon icon={faHeart} color="red" /> in Switzerland by
+          <strong className="has-text-current">
+            <a className="has-text-current" href="https://github.com/f-eld-ch" target="_blank" rel="noopener noreferrer">
+              {" "}F-ELD
             </a>
           </strong>
         </p>


### PR DESCRIPTION
Text color (bulma.io) adapted to adapt depending on use of light or dark mode.

light mode:
<img width="417" alt="SitRep Footer light" src="https://github.com/user-attachments/assets/23444c59-060f-48fb-acdc-c420530cb059">
dark mode:
<img width="417" alt="SitRep Footer dark" src="https://github.com/user-attachments/assets/7082affe-d658-42cb-b2fd-b8f4793e49da">
