### PR TITLE
feat(map): allow WMS layers to be loaded from remote servers

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <html lang="en" class="has-navbar-fixed-top">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://api.mapbox.com; connect-src 'self' ws://* wss://* https://*;"
-    />
-    <meta name="description" content="SitRep" />
-    <link rel="icon" href="/favicon-48x48.ico" sizes="48x48" />
-    <link rel="icon" href="/favicon.ico" sizes="64x64" />
-    <link rel="icon" href="/logo.svg" sizes="any" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
-    <title>Sitrep</title>
-  </head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/index.tsx"></script>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://api.mapbox.com; connect-src 'self' ws://* wss://* https://*;" />
+  <meta name="description" content="SitRep" />
+  <link rel="icon" href="/favicon-48x48.ico" sizes="48x48" />
+  <link rel="icon" href="/favicon.ico" sizes="64x64" />
+  <link rel="icon" href="/logo.svg" sizes="any" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
+  <title>Sitrep</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+
 </html>

--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -16,8 +16,7 @@ $grey-lightest: hsl(221, 14%, 93%);
 $tablet: 769px;
 
 // Override global Sass variables from the /utilities folder
-@use "bulma/sass/utilities" with (
-  $family-primary: "B612",
+@use "bulma/sass/utilities" with ($family-primary: "B612",
   $family-monospace: "B612 Mono",
   $primary: $orange,
   $warning: $yellow,
@@ -36,12 +35,10 @@ $tablet: 769px;
   $grey-light: $grey-light,
   $grey-lighter: $grey-lighter,
   $grey-lightest: $grey-lightest,
-  $tablet: $tablet
-);
+  $tablet: $tablet);
 
 // Import the components we need
-@use "bulma/sass/base" with (
-  $body-overflow-y: "auto"
+@use "bulma/sass/base" with ($body-overflow-y: "auto"
 );
 
 @forward "bulma/sass/helpers";
@@ -50,20 +47,15 @@ $tablet: 769px;
 @forward "bulma/sass/components/breadcrumb";
 @forward "bulma/sass/components/card";
 @forward "bulma/sass/components/dropdown";
-@use "bulma/sass/components/message" with (
-  $message-body-padding: 1em 1.5em 0em 1em
-);
-@use "bulma/sass/components/modal" with (
-  $modal-content-width: 80rem
-);
-@use "bulma/sass/components/navbar" with (
-  $navbar-height: $navbar-height
-);
+@forward "bulma/sass/components/panel" with ($panel-heading-padding: 1em 1.25em,
+  $panel-heading-line-height: 1em, $panel-heading-size: 1em);
+
+@use "bulma/sass/components/message" with ($message-body-padding: 1em 1.5em 0em 1em);
+@use "bulma/sass/components/modal" with ($modal-content-width: 80rem);
+@use "bulma/sass/components/navbar" with ($navbar-height: $navbar-height);
 @forward "bulma/sass/components/tabs";
 
-@use "bulma/sass/form" with (
-  $input-shadow: none
-);
+@use "bulma/sass/form" with ($input-shadow: none);
 
 // Import the bulma elements we need
 @forward "bulma/sass/elements/box";
@@ -77,9 +69,7 @@ $tablet: 769px;
 @forward "bulma/sass/elements/tag";
 @forward "bulma/sass/elements/title";
 
-@use "bulma/sass/layout/footer" with (
-  $footer-padding: 0.5rem 1.5rem 0.5rem
-);
+@use "bulma/sass/layout/footer" with ($footer-padding: 0.5rem 1.5rem 0.5rem);
 @forward "bulma/sass/layout/hero";
 @forward "bulma/sass/layout/section";
 @forward "bulma/sass/layout/level";
@@ -138,8 +128,7 @@ section {
   }
 
   .tbody {
-    tr {
-    }
+    tr {}
   }
 }
 
@@ -164,6 +153,7 @@ section {
 }
 
 @media print {
+
   html,
   body {
     height: initial !important;

--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -48,7 +48,7 @@ $tablet: 769px;
 @forward "bulma/sass/components/card";
 @forward "bulma/sass/components/dropdown";
 @forward "bulma/sass/components/panel" with ($panel-heading-padding: 1em 1.25em,
-  $panel-heading-line-height: 1em, $panel-heading-size: 1em);
+  $panel-heading-line-height: 0.8em, $panel-heading-size: 0.8em);
 
 @use "bulma/sass/components/message" with ($message-body-padding: 1em 1.5em 0em 1em);
 @use "bulma/sass/components/modal" with ($modal-content-width: 80rem);

--- a/ui/src/App.scss
+++ b/ui/src/App.scss
@@ -48,7 +48,8 @@ $tablet: 769px;
 @forward "bulma/sass/components/card";
 @forward "bulma/sass/components/dropdown";
 @forward "bulma/sass/components/panel" with ($panel-heading-padding: 1em 1.25em,
-  $panel-heading-line-height: 0.8em, $panel-heading-size: 0.8em);
+  $panel-heading-line-height: 0.8em,
+  $panel-heading-size: 0.8em);
 
 @use "bulma/sass/components/message" with ($message-body-padding: 1em 1.5em 0em 1em);
 @use "bulma/sass/components/modal" with ($modal-content-width: 80rem);

--- a/ui/src/i18n/locales/de/translations.json
+++ b/ui/src/i18n/locales/de/translations.json
@@ -247,5 +247,20 @@
     "RESET": "zurückgesetzt"
   },
   "write": "schreiben",
-  "updateNotification": "Eine neue Version der Anwendung ist verfügbar. Bitte aktualisieren Sie die Seite mit dem Refresh-Button."
+  "updateNotification": "Eine neue Version der Anwendung ist verfügbar. Bitte aktualisieren Sie die Seite mit dem Refresh-Button.",
+  "wmsLayerMenu": {
+    "selectServer": "WMS-Server auswählen",
+    "customServer": "Benutzerdefinierter Server",
+    "enterServerUrl": "WMS-Server-URL eingeben",
+    "fetchLayers": "Layer abrufen",
+    "selectLayer": "Layer auswählen"
+  },
+  "layerControl": {
+    "layers": "Layer",
+    "activeLayers": "Aktive Layer",
+    "addWmsLayers": "WMS-Layer hinzufügen"
+  },
+  "styleController": {
+    "maps": "Karten"
+  }
 }

--- a/ui/src/i18n/locales/en/translations.json
+++ b/ui/src/i18n/locales/en/translations.json
@@ -247,5 +247,20 @@
     "RESET": "reset"
   },
   "write": "write",
-  "updateNotification": "A new version is available. Please refresh the page with the refresh button."
+  "updateNotification": "A new version is available. Please refresh the page with the refresh button.",
+  "wmsLayerMenu": {
+    "selectServer": "Select WMS Server",
+    "customServer": "Custom Server",
+    "enterServerUrl": "Enter WMS Server URL",
+    "fetchLayers": "Fetch Layers",
+    "selectLayer": "Select a layer"
+  },
+  "layerControl": {
+    "layers": "Layers",
+    "activeLayers": "Active Layers",
+    "addWmsLayers": "Add WMS Layers"
+  },
+  "styleController": {
+    "maps": "Maps"
+  }
 }

--- a/ui/src/i18n/locales/fr/translations.json
+++ b/ui/src/i18n/locales/fr/translations.json
@@ -237,6 +237,9 @@
   "short": "abréviation",
   "showClosed": "Afficher fermé",
   "state": "était debout",
+  "styleController": {
+    "maps": "Cartes"
+  },
   "tasks": "affaires en cours",
   "tasksOrders": "Articles / commandes en attente",
   "tasksRequestOrders": "Besoins / En attente / Demandes",
@@ -245,6 +248,17 @@
     "MOREINFO": "besoin de plus d'informations",
     "PENDING": "en attente",
     "RESET": "réinitialiser"
+  },
+  "layerControl": {
+    "layers": "Calques",
+    "activeLayers": "Calques actives",
+    "addWmsLayers": "Ajouter des calques WMS"
+  },
+  "wmsLayerMenu": {
+    "customServer": "Serveur personnalisé",
+    "enterServerUrl": "Entrez l'URL du serveur",
+    "fetchLayers": "Récupérer les calques",
+    "selectLayer": "Sélectionner une calques"
   },
   "write": "écrivez",
   "updateNotification": "Une nouvelle version de l'application est disponible. Veuillez actualiser la page en cliquant sur le bouton Refresh."

--- a/ui/src/i18n/locales/it/translations.json
+++ b/ui/src/i18n/locales/it/translations.json
@@ -237,6 +237,9 @@
   "short": "abbreviazione",
   "showClosed": "mostra chiusa",
   "state": "stava in piedi",
+  "styleController": {
+    "maps": "Carte"
+  },
   "tasks": "faccende in sospeso",
   "tasksOrders": "Articoli / ordini in sospeso",
   "tasksRequestOrders": "Bisogni / In attesa / Richieste",
@@ -245,6 +248,17 @@
     "MOREINFO": "più informazioni necessarie",
     "PENDING": "in attesa di",
     "RESET": "ripristina"
+  },
+  "layerControl": {
+    "layers": "Livelli",
+    "activeLayers": "Livelli attivi",
+    "addWmsLayers": "Aggiungi livelli WMS"
+  },
+  "wmsLayerMenu": {
+    "customServer": "Server personalizzato",
+    "enterServerUrl": "Inserisci l'URL del server",
+    "fetchLayers": "Recupera livelli",
+    "selectLayer": "Seleziona livello"
   },
   "write": "scrivere",
   "updateNotification": "È disponibile una nuova versione dell'applicazione. Si prega di aggiornare la pagina con il pulsante di aggiornamento."

--- a/ui/src/views/map/ActiveWMSLayers.tsx
+++ b/ui/src/views/map/ActiveWMSLayers.tsx
@@ -1,0 +1,38 @@
+import { useContext } from "react";
+import { Source, Layer as MapLayer } from "react-map-gl/maplibre";
+import { LayerContext, WMSLayer } from "./LayerContext";
+
+const ActiveWMSLayers = () => {
+    const { state } = useContext(LayerContext);
+    if (!state.wmsLayers) {
+        return null;
+    }
+
+    return (
+        <>
+            {state.wmsLayers
+                .filter((layer: WMSLayer) => layer.isVisible)
+                .map((layer: WMSLayer) => (
+                    <Source
+                        key={layer.name}
+                        id={layer.name}
+                        type="raster"
+                        tiles={[
+                            `${layer.server}?REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=image%2Fpng&STYLES=&TRANSPARENT=TRUE&LAYERS=${layer.name}&CRS=EPSG%3A3857&SRS=EPSG%3A3857&WIDTH=512&HEIGHT=512&FORMAT_OPTIONS=dpi%3A180&BBOX={bbox-epsg-3857}`,
+                        ]}
+                        tileSize={512}
+                    >
+                        <MapLayer
+                            id={layer.name}
+                            type="raster"
+                            paint={{
+                                "raster-opacity": layer.opacity,
+                            }}
+                        />
+                    </Source>
+                ))}
+        </>
+    );
+};
+
+export default ActiveWMSLayers;

--- a/ui/src/views/map/LayerContext.tsx
+++ b/ui/src/views/map/LayerContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer } from "react";
-import { LayersAction, layersReducer, selectedFeatureReducer, activeLayerReducer, drawReducer } from "./reducer";
+import { LayersAction, layersReducer, selectedFeatureReducer, activeLayerReducer, drawReducer, wmsLayersReducer } from "./reducer";
 import { Layer } from "types/layer";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 
@@ -7,12 +7,22 @@ export type SelectedFeatureState = string | undefined;
 export type LayersState = Layer[];
 export type ActiveLayerState = string | undefined;
 export type DrawState = MapboxDraw | undefined;
+export type WMSLayersState = WMSLayer[];
+
+export interface WMSLayer {
+  name: string;
+  title: string;
+  server: string;
+  opacity: number;
+  isVisible: boolean;
+}
 
 export interface LayerState {
   layers: LayersState;
   activeLayer: string | undefined;
   selectedFeature: SelectedFeatureState;
   draw: DrawState;
+  wmsLayers: WMSLayersState;
 }
 
 const initialState: LayerState = {
@@ -20,6 +30,7 @@ const initialState: LayerState = {
   activeLayer: undefined,
   selectedFeature: undefined,
   draw: undefined,
+  wmsLayers: [],
 };
 
 const LayerContext = createContext<{
@@ -30,11 +41,12 @@ const LayerContext = createContext<{
   dispatch: () => null,
 });
 
-const mainReducer = ({ layers, activeLayer, selectedFeature, draw }: LayerState, action: LayersAction) => ({
+const mainReducer = ({ layers, activeLayer, selectedFeature, draw, wmsLayers }: LayerState, action: LayersAction) => ({
   layers: layersReducer(layers, action),
   activeLayer: activeLayerReducer(activeLayer, action),
   selectedFeature: selectedFeatureReducer(selectedFeature, action),
   draw: drawReducer(draw, action),
+  wmsLayers: wmsLayersReducer(wmsLayers, action),
 });
 
 const LayersProvider = ({ children }: { children: React.ReactNode }) => {

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -100,7 +100,7 @@ function Layers() {
 
   return (
     <>
-      <div className="maplibregl-ctrl-bottom-right">
+      <div className="maplibregl-ctrl-bottom-right is-flex is-flex-direction-column mx-2 my-2">
         <LayerControl />
         <StyleController />
       </div>

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -395,12 +395,10 @@ function InactiveLayer(props: { featureCollection: FeatureCollection; id: string
   return (
     <>
       <EnrichedSymbolSource id={id} featureCollection={featureCollection} />
-
       <Source key={id} id={id} type="geojson" data={featureCollection}>
         {displayStyle.map((s) => (
           <MapLayer key={s.id} id={s.id + id} {...s} />
         ))}
-
       </Source>
     </>
   );

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -42,6 +42,7 @@ import maplibregl from "maplibre-gl";
 import classNames from "classnames";
 import SearchControl from "./controls/Searchbox";
 import { validate as validateUUID, v3 as uuidv3 } from "uuid";
+import ActiveWMSLayers from "./ActiveWMSLayers";
 
 const modes = {
   ...MapboxDraw.modes,
@@ -89,7 +90,7 @@ function MapView() {
           {/* Layersprovider and Draw */}
           <Layers />
         </Map>
-      </div>
+      </div >
     </>
   );
 }
@@ -110,6 +111,7 @@ function Layers() {
 
       {/* Inactive Layers */}
       <InactiveLayers layers={state.layers.filter((l) => l.id !== state.activeLayer) || []} />
+      <ActiveWMSLayers />
     </>
   );
 }
@@ -393,10 +395,12 @@ function InactiveLayer(props: { featureCollection: FeatureCollection; id: string
   return (
     <>
       <EnrichedSymbolSource id={id} featureCollection={featureCollection} />
+
       <Source key={id} id={id} type="geojson" data={featureCollection}>
         {displayStyle.map((s) => (
           <MapLayer key={s.id} id={s.id + id} {...s} />
         ))}
+
       </Source>
     </>
   );

--- a/ui/src/views/map/controls/ActiveLayersControl.tsx
+++ b/ui/src/views/map/controls/ActiveLayersControl.tsx
@@ -1,0 +1,61 @@
+import React, { useContext } from "react";
+import { LayerContext, WMSLayer } from "../LayerContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { Layer } from "types/layer";
+
+const ActiveLayersControl: React.FC = () => {
+    const { state, dispatch } = useContext(LayerContext);
+
+    const handleVisibilityToggle = (layerName: string, isVisible: boolean) => {
+        dispatch({ type: "TOGGLE_LAYER_VISIBILITY", payload: { layerName, isVisible } });
+    };
+
+    const handleWMSOpacityChange = (layerName: string, opacity: number) => {
+        dispatch({ type: "UPDATE_WMS_LAYER_OPACITY", payload: { layerName, opacity } });
+    };
+
+    const handleLayerClick = (layerId: string) => {
+        dispatch({ type: "SET_ACTIVE_LAYER", payload: { layerId } });
+    };
+
+    const handleDeleteLayer = (layerName: string) => {
+        dispatch({ type: "REMOVE_WMS_LAYER", payload: { layerName } });
+    };
+
+    return (
+        <div className="active-layers-control">
+            {state.layers.map((layer: Layer) => (
+                <div key={layer.id} className="panel-block is-align-items-flex-end is-justify-content-space-between" >
+                    <span onClick={() => handleLayerClick(layer.id)}>{layer.name}</span>
+                </div>
+            ))}
+            {state.wmsLayers.map((layer: WMSLayer) => (
+                <div key={layer.name} className="panel-block is-align-items-flex-start is-justify-content-space-between">
+                    <div className="mr-3">
+                        <span>{layer.title}</span>
+                    </div>
+                    <div className="is-align-items-flex-end">
+                        <button onClick={() => handleVisibilityToggle(layer.name, !layer.isVisible)} style={{ marginRight: "10px" }}>
+                            <FontAwesomeIcon icon={layer.isVisible ? faEye : faEyeSlash} />
+                        </button>
+                        <input
+                            type="range"
+                            min="0"
+                            max="1"
+                            step="0.1"
+                            value={layer.opacity}
+                            onChange={(e) => handleWMSOpacityChange(layer.name, parseFloat(e.target.value))}
+                            style={{ marginRight: "10px" }}
+                        />
+                        <button onClick={() => handleDeleteLayer(layer.name)}>
+                            <FontAwesomeIcon icon={faTrash} />
+                        </button>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default ActiveLayersControl;

--- a/ui/src/views/map/controls/ActiveLayersControl.tsx
+++ b/ui/src/views/map/controls/ActiveLayersControl.tsx
@@ -1,8 +1,9 @@
 import React, { useContext } from "react";
 import { LayerContext, WMSLayer } from "../LayerContext";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEye, faEyeSlash, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faEye, faEyeSlash, faTrash, faHexagonNodesBolt, faDrawPolygon } from "@fortawesome/free-solid-svg-icons";
 import { Layer } from "types/layer";
+import classNames from "classnames";
 
 const ActiveLayersControl: React.FC = () => {
     const { state, dispatch } = useContext(LayerContext);
@@ -24,15 +25,24 @@ const ActiveLayersControl: React.FC = () => {
     };
 
     return (
-        <div className="active-layers-control">
+        <div className="active-layers-control is-size-7">
             {state.layers.map((layer: Layer) => (
-                <div key={layer.id} className="panel-block is-align-items-flex-end is-justify-content-space-between" >
-                    <span onClick={() => handleLayerClick(layer.id)}>{layer.name}</span>
+                <div key={layer.id} className={classNames({ "panel-block": true, "is-align-items-flex-start": true, "is-justify-content-space-between": true, "is-active": state.activeLayer === layer.name })}>
+                    <div className="mr-3 is-align-items-flex-start is-align-content-center">
+                        <span className="panel-icon" style={{ verticalAlign: "center" }}>
+                            <FontAwesomeIcon icon={faDrawPolygon} size="lg" />
+                        </span>
+                        <a onClick={() => handleLayerClick(layer.id)}>{layer.name}</a>
+                    </div>
                 </div>
+
             ))}
             {state.wmsLayers.map((layer: WMSLayer) => (
                 <div key={layer.name} className="panel-block is-align-items-flex-start is-justify-content-space-between">
-                    <div className="mr-3">
+                    <div className="mr-3 is-align-items-flex-start is-align-content-center">
+                        <span className="panel-icon" style={{ verticalAlign: "center" }}>
+                            <FontAwesomeIcon icon={faHexagonNodesBolt} size="lg" />
+                        </span>
                         <span>{layer.title}</span>
                     </div>
                     <div className="is-align-items-flex-end">
@@ -53,8 +63,9 @@ const ActiveLayersControl: React.FC = () => {
                         </button>
                     </div>
                 </div>
-            ))}
-        </div>
+            ))
+            }
+        </div >
     );
 };
 

--- a/ui/src/views/map/controls/LayerControl.tsx
+++ b/ui/src/views/map/controls/LayerControl.tsx
@@ -21,7 +21,7 @@ function LayerPanel() {
 
   if (!active) {
     return (
-      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black my-3">
+      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black is-align-self-flex-end">
         <button type="button" className={btnClass} onClick={() => setActive(!active)}>
           <FontAwesomeIcon icon={faLayerGroup} size="lg" />
         </button>
@@ -30,12 +30,13 @@ function LayerPanel() {
   }
 
   return (
-    <nav className="panel has-background-white my-3 mx-2" style={{ pointerEvents: "auto" }}>
-      <p className="panel-heading">
+    <nav className="panel has-background-white is-align-self-flex-end" style={{ pointerEvents: "auto" }}>
+      <p className="panel-heading is-flex is-justify-content-space-between is-align-items-center is-size-6">
         {t("layerControl.layers")}
-        <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
+        <button className="delete is-align-self-flex-end" onClick={() => setActive(!active)}></button>
       </p>
-      <div className="panel-tabs">
+
+      <div className="panel-tabs is-size-7">
         <a
           className={classNames({ "is-active": activeTab === "drawing" })}
           onClick={() => setActiveTab("drawing")}

--- a/ui/src/views/map/controls/LayerControl.tsx
+++ b/ui/src/views/map/controls/LayerControl.tsx
@@ -6,10 +6,12 @@ import "./LayerControl.scss";
 import classNames from "classnames";
 import WMSLayerMenu from "./WMSLayerMenu";
 import ActiveLayersControl from "./ActiveLayersControl";
+import { useTranslation } from "react-i18next";
 
 function LayerPanel() {
   const [active, setActive] = useState<boolean>(false);
   const [activeTab, setActiveTab] = useState<string>("drawing");
+  const { t } = useTranslation();
 
   const btnClass = classNames({
     "maplibregl-ctrl-icon": true,
@@ -30,7 +32,7 @@ function LayerPanel() {
   return (
     <nav className="panel has-background-white my-3 mx-2" style={{ pointerEvents: "auto" }}>
       <p className="panel-heading">
-        Layers
+        {t("layerControl.layers")}
         <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
       </p>
       <div className="panel-tabs">
@@ -38,13 +40,13 @@ function LayerPanel() {
           className={classNames({ "is-active": activeTab === "drawing" })}
           onClick={() => setActiveTab("drawing")}
         >
-          Active Layers
+          {t("layerControl.activeLayers")}
         </a>
         <a
           className={classNames({ "is-active": activeTab === "wms" })}
           onClick={() => setActiveTab("wms")}
         >
-          Add WMS Layers
+          {t("layerControl.addWmsLayers")}
         </a>
       </div>
       {activeTab === "drawing" && <ActiveLayersControl />}
@@ -52,6 +54,5 @@ function LayerPanel() {
     </nav >
   );
 }
-
 
 export default React.memo(LayerPanel);

--- a/ui/src/views/map/controls/LayerControl.tsx
+++ b/ui/src/views/map/controls/LayerControl.tsx
@@ -1,15 +1,15 @@
 import { faLayerGroup } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "maplibre-gl/dist/maplibre-gl.css";
-import React, { useCallback, useContext, useState } from "react";
+import React, { useState } from "react";
 import "./LayerControl.scss";
-import { Layer } from "types/layer";
 import classNames from "classnames";
-import { LayerContext } from "../LayerContext";
+import WMSLayerMenu from "./WMSLayerMenu";
+import ActiveLayersControl from "./ActiveLayersControl";
 
 function LayerPanel() {
   const [active, setActive] = useState<boolean>(false);
-  const { state, dispatch } = useContext(LayerContext);
+  const [activeTab, setActiveTab] = useState<string>("drawing");
 
   const btnClass = classNames({
     "maplibregl-ctrl-icon": true,
@@ -17,42 +17,41 @@ function LayerPanel() {
     "is-hidden": active,
   });
 
-  const switcherClass = classNames({
-    "maplibregl-layer-list": true,
-    "maplibregl-ctrl-icon": true,
-    "is-hidden": !active,
-    "mr-50": true,
-  });
-
-  const onClick = useCallback(
-    (l: Layer) => {
-      setActive(false);
-      dispatch({ type: "SET_ACTIVE_LAYER", payload: { layerId: l.id } });
-    },
-    [dispatch],
-  );
+  if (!active) {
+    return (
+      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black my-3">
+        <button type="button" className={btnClass} onClick={() => setActive(!active)}>
+          <FontAwesomeIcon icon={faLayerGroup} size="lg" />
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black">
-      <button type="button" className={btnClass} onClick={() => setActive(!active)}>
-        <FontAwesomeIcon icon={faLayerGroup} size="lg" />
-      </button>
-      <div className={switcherClass}>
-        {state.layers.map((l) => {
-          return (
-            <button
-              type="button"
-              className={classNames({ button: true, active: state.activeLayer === l.id })}
-              key={l.id}
-              onClick={() => onClick(l)}
-            >
-              {l.name}
-            </button>
-          );
-        })}
+    <nav className="panel has-background-white my-3 mx-2" style={{ pointerEvents: "auto" }}>
+      <p className="panel-heading">
+        Layers
+        <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
+      </p>
+      <div className="panel-tabs">
+        <a
+          className={classNames({ "is-active": activeTab === "drawing" })}
+          onClick={() => setActiveTab("drawing")}
+        >
+          Active Layers
+        </a>
+        <a
+          className={classNames({ "is-active": activeTab === "wms" })}
+          onClick={() => setActiveTab("wms")}
+        >
+          Add WMS Layers
+        </a>
       </div>
-    </div>
+      {activeTab === "drawing" && <ActiveLayersControl />}
+      {activeTab === "wms" && <WMSLayerMenu disable={() => { setActiveTab("drawing") }} />}
+    </nav >
   );
 }
+
 
 export default React.memo(LayerPanel);

--- a/ui/src/views/map/controls/StyleController.tsx
+++ b/ui/src/views/map/controls/StyleController.tsx
@@ -3,6 +3,7 @@ import { faMap } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import React, { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import "./StyleController.scss";
 import { StyleSpecification } from "maplibre-gl";
 import basisKarte from "assets/map/styles/ch.swisstopo.leichte-basiskarte.vt.json";
@@ -60,6 +61,8 @@ function StyleController() {
 
   const style = useReactiveVar(selectedStyle);
 
+  const { t } = useTranslation();
+
   const btnClass = classNames({
     "maplibregl-ctrl-icon": true,
   });
@@ -85,12 +88,11 @@ function StyleController() {
   return (
     <nav className="panel has-background-white" style={{ pointerEvents: "auto" }}>
       <p className="panel-heading">
-        Karten
+        {t("styleController.maps")}
         <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
       </p>
       {MapStyles.map((s) => (
         <div className="panel-block">
-
           <a
             key={s.name}
             className={classNames({ "is-active": style.name === s.name })}

--- a/ui/src/views/map/controls/StyleController.tsx
+++ b/ui/src/views/map/controls/StyleController.tsx
@@ -77,7 +77,7 @@ function StyleController() {
 
   if (!active) {
     return (
-      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black">
+      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black is-align-self-flex-end">
         <button type="button" className={btnClass} onClick={() => setActive(!active)}>
           <FontAwesomeIcon icon={faMap} size="lg" />
         </button>
@@ -86,13 +86,13 @@ function StyleController() {
   }
 
   return (
-    <nav className="panel has-background-white" style={{ pointerEvents: "auto" }}>
-      <p className="panel-heading">
-        {t("styleController.maps")}
-        <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
+    <nav className="panel has-background-white is-align-self-flex-end" style={{ pointerEvents: "auto" }}>
+      <p className="panel-heading is-flex is-justify-content-space-between is-align-items-center is-size-6">
+        <span className="px-2">{t("styleController.maps")}</span>
+        <button className="delete is-align-self-flex-end" onClick={() => setActive(!active)}></button>
       </p>
       {MapStyles.map((s) => (
-        <div className="panel-block">
+        <div className="panel-block is-size-7">
           <a
             key={s.name}
             className={classNames({ "is-active": style.name === s.name })}

--- a/ui/src/views/map/controls/StyleController.tsx
+++ b/ui/src/views/map/controls/StyleController.tsx
@@ -16,7 +16,7 @@ const MapStyles: MapStyle[] = [
   {
     name: "Satellit",
     style: ExpandRelativeURLs(basisKarteImagery as StyleSpecification),
-  },
+  }
 ];
 
 function ExpandRelativeURLs(previousStyle: StyleSpecification): StyleSpecification {
@@ -37,13 +37,13 @@ function ExpandRelativeURLs(previousStyle: StyleSpecification): StyleSpecificati
           ? previousStyle.sprite
           : new URL(previousStyle.sprite, window.location.href).href
         : Object.assign(
-            [],
-            previousStyle.sprite?.map((s) => {
-              return Object.assign({}, s, {
-                url: s.url.startsWith("http") ? s.url?.toString() : new URL(s.url, window.location.href).href,
-              });
-            }),
-          ),
+          [],
+          previousStyle.sprite?.map((s) => {
+            return Object.assign({}, s, {
+              url: s.url.startsWith("http") ? s.url?.toString() : new URL(s.url, window.location.href).href,
+            });
+          }),
+        ),
   };
 }
 
@@ -62,14 +62,6 @@ function StyleController() {
 
   const btnClass = classNames({
     "maplibregl-ctrl-icon": true,
-    active: active,
-    "is-hidden": active,
-  });
-
-  const switcherClass = classNames({
-    "maplibregl-style-list": true,
-    "maplibregl-ctrl-icon": true,
-    "is-hidden": !active,
   });
 
   const onClick = useCallback(
@@ -80,26 +72,36 @@ function StyleController() {
     [setActive],
   );
 
-  return (
-    <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black">
-      <button type="button" className={btnClass} onClick={() => setActive(!active)}>
-        <FontAwesomeIcon icon={faMap} size="lg" />
-      </button>
-      <div className={switcherClass}>
-        {MapStyles.map((s) => {
-          return (
-            <button
-              type="button"
-              className={classNames({ button: true, active: style.name === s.name })}
-              key={s.name}
-              onClick={() => onClick(s)}
-            >
-              {s.name}
-            </button>
-          );
-        })}
+  if (!active) {
+    return (
+      <div className="maplibregl-ctrl maplibregl-ctrl-group has-text-black">
+        <button type="button" className={btnClass} onClick={() => setActive(!active)}>
+          <FontAwesomeIcon icon={faMap} size="lg" />
+        </button>
       </div>
-    </div>
+    )
+  }
+
+  return (
+    <nav className="panel has-background-white" style={{ pointerEvents: "auto" }}>
+      <p className="panel-heading">
+        Karten
+        <button className="delete is-pulled-right" onClick={() => setActive(!active)}></button>
+      </p>
+      {MapStyles.map((s) => (
+        <div className="panel-block">
+
+          <a
+            key={s.name}
+            className={classNames({ "is-active": style.name === s.name })}
+            onClick={() => onClick(s)}
+          >
+            {s.name}
+          </a>
+        </div>
+
+      ))}
+    </nav>
   );
 }
 

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { LayerContext } from "../LayerContext";
+import { useTranslation } from "react-i18next";
+import classNames from "classnames";
 
 interface Layer {
     name: string;
@@ -7,51 +9,115 @@ interface Layer {
     key: string;
 }
 
+const WMS_SERVERS = [
+    { name: "geo.admin.ch", url: "https://wms.geo.admin.ch" },
+    { name: "geo.ur.ch", url: "https://geo.ur.ch/wms" },
+    { name: "sitn.ne.ch", url: "https://sitn.ne.ch/services/wms" },
+    { name: "map.geo.sz.ch", url: "https://map.geo.sz.ch/mapserv_proxy" },
+];
+
 const WMSLayerMenu = (props: { disable: () => void }) => {
     const [layers, setLayers] = useState<Layer[]>([]);
     const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
+    const [selectedServer, setSelectedServer] = useState<string>(WMS_SERVERS[0].url);
+    const [customServer, setCustomServer] = useState<string>("");
+    const [isLoading, setIsLoading] = useState<boolean>(false);
     const { dispatch } = useContext(LayerContext);
     const { disable } = props;
-    const server = "https://geo.ur.ch/wms";
+    const { t } = useTranslation();
 
     useEffect(() => {
-        fetch(`${server}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities`)
-            .then((response) => response.text())
-            .then((data) => {
-                const parser = new DOMParser();
-                const xml = parser.parseFromString(data, "text/xml");
-                const layerElements = xml.getElementsByTagName("Layer");
-                const layers = Array.from(layerElements).map((layer, index) => ({
-                    name: layer.getElementsByTagName("Name")[0].textContent || "",
-                    title: layer.getElementsByTagName("Title")[0].textContent || "",
-                    key: `${layer.getElementsByTagName("Name")[0].textContent || ""}-${index}`,
-                }));
-                setLayers(layers);
-            })
-            .catch((error) => console.error("Error fetching WMS layers:", error));
-    }, [server]);
+        if (selectedServer) {
+            setIsLoading(true);
+            fetch(`${selectedServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities`)
+                .then((response) => response.text())
+                .then((data) => {
+                    const parser = new DOMParser();
+                    const xml = parser.parseFromString(data, "text/xml");
+                    const layerElements = xml.getElementsByTagName("Layer");
+                    const layers = Array.from(layerElements).map((layer, index) => ({
+                        name: layer.getElementsByTagName("Name")[0].textContent || "",
+                        title: layer.getElementsByTagName("Title")[0].textContent || "",
+                        key: `${layer.getElementsByTagName("Name")[0].textContent || ""}-${index}`,
+                    }));
+                    setLayers(layers);
+                    setIsLoading(false);
+                })
+                .catch((error) => { console.error("Error fetching WMS layers:", error); setIsLoading(false); });
+        }
+    }, [selectedServer]);
 
     const handleLayerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const layerName = event.target.value;
         const layer = layers.find((l) => l.name === layerName);
         if (layer) {
             setSelectedLayer(layerName);
-            dispatch({ type: "ADD_WMS_LAYER", payload: { layerName: layerName, title: layer.title, opacity: 0.7, server: server } });
+            dispatch({ type: "ADD_WMS_LAYER", payload: { layerName: layerName, title: layer.title, opacity: 0.7, server: selectedServer } });
             disable();
         }
     };
 
+    const handleServerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        setSelectedServer(event.target.value);
+        setCustomServer("");
+    };
+
+    const handleCustomServerChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setCustomServer(event.target.value);
+    };
+
+    const handleCustomServerSubmit = () => {
+        setSelectedServer(customServer);
+    };
+
     return (
         <div className="panel-block is-align-items-flex-start is-justify-content-space-between">
-            <select className="is-align-items-flex-start is-justify-content-space-between" onChange={handleLayerSelect} value={selectedLayer || ""}>
-                <option value="" disabled>Select a layer</option>
-                {layers.map((layer) => (
-                    <option key={layer.key} value={layer.name}>
-                        {layer.title}
-                    </option>
-                ))}
-            </select>
-        </div>
+            <div className="columns">
+                <div className="column">
+                    <div className="select is-small" >
+                        <select className="mb-2" onChange={handleServerSelect} value={selectedServer}>
+                            {WMS_SERVERS.map((server) => (
+                                <option key={server.url} value={server.url}>
+                                    {server.name}
+                                </option>
+                            ))}
+                            <option value="">{t("wmsLayerMenu.customServer")}</option>
+                        </select>
+                    </div>
+                </div>
+
+                {selectedServer == "" && (
+                    <div className="column">
+                        <input
+                            type="text"
+                            placeholder={t("wmsLayerMenu.enterServerUrl")}
+                            value={customServer}
+                            onChange={handleCustomServerChange}
+                            className="input is-small mb-2"
+                        />
+
+                        <button onClick={handleCustomServerSubmit} className="button is-primary">
+                            {t("wmsLayerMenu.fetchLayers")}
+                        </button>
+                    </div>
+                )}
+                {selectedServer && (
+                    <div className="column">
+                        <div className={classNames({ "select": true, "is-small": true, "is-loading": isLoading })}>
+                            <select className="is-align-items-flex-start is-justify-content-space-between" onChange={handleLayerSelect} value={selectedLayer || ""}>
+                                <option value="" disabled>{t("wmsLayerMenu.selectLayer")}</option>
+                                {layers.map((layer) => (
+                                    <option key={layer.key} value={layer.name}>
+                                        {layer.title}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    </div>
+
+                )}
+            </div>
+        </div >
     );
 };
 

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState, useContext } from "react";
+import { LayerContext } from "../LayerContext";
+
+interface Layer {
+    name: string;
+    title: string;
+    key: string;
+}
+
+const WMSLayerMenu = (props: { disable: () => void }) => {
+    const [layers, setLayers] = useState<Layer[]>([]);
+    const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
+    const { dispatch } = useContext(LayerContext);
+    const { disable } = props;
+    const server = "https://geo.ur.ch/wms";
+
+    useEffect(() => {
+        fetch(`${server}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities`)
+            .then((response) => response.text())
+            .then((data) => {
+                const parser = new DOMParser();
+                const xml = parser.parseFromString(data, "text/xml");
+                const layerElements = xml.getElementsByTagName("Layer");
+                const layers = Array.from(layerElements).map((layer, index) => ({
+                    name: layer.getElementsByTagName("Name")[0].textContent || "",
+                    title: layer.getElementsByTagName("Title")[0].textContent || "",
+                    key: `${layer.getElementsByTagName("Name")[0].textContent || ""}-${index}`,
+                }));
+                setLayers(layers);
+            })
+            .catch((error) => console.error("Error fetching WMS layers:", error));
+    }, [server]);
+
+    const handleLayerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const layerName = event.target.value;
+        const layer = layers.find((l) => l.name === layerName);
+        if (layer) {
+            setSelectedLayer(layerName);
+            dispatch({ type: "ADD_WMS_LAYER", payload: { layerName: layerName, title: layer.title, opacity: 0.7, server: server } });
+            disable();
+        }
+    };
+
+    return (
+        <div className="panel-block is-align-items-flex-start is-justify-content-space-between">
+            <select className="is-align-items-flex-start is-justify-content-space-between" onChange={handleLayerSelect} value={selectedLayer || ""}>
+                <option value="" disabled>Select a layer</option>
+                {layers.map((layer) => (
+                    <option key={layer.key} value={layer.name}>
+                        {layer.title}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+};
+
+export default WMSLayerMenu;

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -16,18 +16,28 @@ const WMS_SERVERS = [
     { name: "map.geo.sz.ch", url: "https://map.geo.sz.ch/mapserv_proxy" },
 ];
 
+const getBaseDomain = (url: string) => {
+    try {
+        return new URL(url).hostname;
+    } catch (error) {
+        console.error("Invalid URL:", error);
+        return url;
+    }
+};
+
 const WMSLayerMenu = (props: { disable: () => void }) => {
     const [layers, setLayers] = useState<Layer[]>([]);
     const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
     const [selectedServer, setSelectedServer] = useState<string>(WMS_SERVERS[0].url);
     const [customServer, setCustomServer] = useState<string>("");
     const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [serverLayersCache, setServerLayersCache] = useState<Record<string, Layer[]>>({});
     const { dispatch } = useContext(LayerContext);
     const { disable } = props;
     const { t } = useTranslation();
 
     useEffect(() => {
-        if (selectedServer) {
+        if (selectedServer && !serverLayersCache[selectedServer]) {
             setIsLoading(true);
             fetch(`${selectedServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities`)
                 .then((response) => response.text())
@@ -41,11 +51,14 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
                         key: `${layer.getElementsByTagName("Name")[0].textContent || ""}-${index}`,
                     }));
                     setLayers(layers);
+                    setServerLayersCache((prevCache) => ({ ...prevCache, [selectedServer]: layers }));
                     setIsLoading(false);
                 })
                 .catch((error) => { console.error("Error fetching WMS layers:", error); setIsLoading(false); });
+        } else if (serverLayersCache[selectedServer]) {
+            setLayers(serverLayersCache[selectedServer]);
         }
-    }, [selectedServer]);
+    }, [selectedServer, serverLayersCache]);
 
     const handleLayerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
         const layerName = event.target.value;
@@ -67,7 +80,12 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
     };
 
     const handleCustomServerSubmit = () => {
-        setSelectedServer(customServer);
+        if (customServer) {
+            const baseDomain = getBaseDomain(customServer);
+            setSelectedServer(customServer);
+            WMS_SERVERS.push({ name: baseDomain, url: customServer });
+            setCustomServer("");
+        }
     };
 
     return (

--- a/ui/src/views/map/reducer.tsx
+++ b/ui/src/views/map/reducer.tsx
@@ -1,5 +1,5 @@
 import { Layer } from "types/layer";
-import { ActiveLayerState, DrawState, LayersState, SelectedFeatureState } from "./LayerContext";
+import { ActiveLayerState, DrawState, LayersState, SelectedFeatureState, WMSLayersState } from "./LayerContext";
 import { first } from "lodash";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 
@@ -11,7 +11,12 @@ export type LayersAction =
   | SelectFeatureAction
   | DeselectFeature
   | SetActiveLayer
-  | SetDrawLayer;
+  | SetDrawLayer
+  | AddWMSLayerAction
+  | UpdateWMSLayerOpacityAction
+  | ToggleLayerVisibilityAction
+  | UpdateLayerOpacityAction
+  | RemoveWMSLayerAction;
 
 export interface SetLayerAction {
   type: "SET_LAYERS";
@@ -60,6 +65,47 @@ export interface SetDrawLayer {
   };
 }
 
+export interface AddWMSLayerAction {
+  type: "ADD_WMS_LAYER";
+  payload: {
+    layerName: string;
+    title: string;
+    opacity: number;
+    server: string;
+  };
+}
+
+export interface UpdateWMSLayerOpacityAction {
+  type: "UPDATE_WMS_LAYER_OPACITY";
+  payload: {
+    layerName: string;
+    opacity: number;
+  };
+}
+
+export interface ToggleLayerVisibilityAction {
+  type: "TOGGLE_LAYER_VISIBILITY";
+  payload: {
+    layerName: string;
+    isVisible: boolean;
+  };
+}
+
+export interface UpdateLayerOpacityAction {
+  type: "UPDATE_LAYER_OPACITY";
+  payload: {
+    layerName: string;
+    opacity: number;
+  };
+}
+
+export interface RemoveWMSLayerAction {
+  type: "REMOVE_WMS_LAYER";
+  payload: {
+    layerName: string;
+  };
+}
+
 export const layersReducer = (state: LayersState, action: LayersAction) => {
   switch (action.type) {
     case "SET_LAYERS":
@@ -68,6 +114,14 @@ export const layersReducer = (state: LayersState, action: LayersAction) => {
       return [...state, action.payload.layer];
     case "REMOVE_LAYER":
       return [...state.filter((layer) => layer.id !== action.payload.id)];
+    case "TOGGLE_LAYER_VISIBILITY":
+      return state.map((layer) =>
+        layer.id === action.payload.layerName ? { ...layer, isVisible: action.payload.isVisible } : layer
+      );
+    case "UPDATE_LAYER_OPACITY":
+      return state.map((layer) =>
+        layer.id === action.payload.layerName ? { ...layer, opacity: action.payload.opacity } : layer
+      );
     default:
       return state;
   }
@@ -103,6 +157,28 @@ export const drawReducer = (state: DrawState, action: LayersAction) => {
   switch (action.type) {
     case "SET_DRAW":
       return action.payload.draw;
+    default:
+      return state;
+  }
+};
+
+export const wmsLayersReducer = (state: WMSLayersState, action: LayersAction) => {
+  switch (action.type) {
+    case "ADD_WMS_LAYER":
+      if (state.some((layer) => layer.name === action.payload.layerName)) {
+        return state;
+      }
+      return [...state, { name: action.payload.layerName, title: action.payload.title, opacity: action.payload.opacity, server: action.payload.server, isVisible: true }];
+    case "UPDATE_WMS_LAYER_OPACITY":
+      return state.map((layer) =>
+        layer.name === action.payload.layerName ? { ...layer, opacity: action.payload.opacity } : layer
+      );
+    case "TOGGLE_LAYER_VISIBILITY":
+      return state.map((layer) =>
+        layer.name === action.payload.layerName ? { ...layer, isVisible: action.payload.isVisible } : layer
+      );
+    case "REMOVE_WMS_LAYER":
+      return state.filter((layer) => layer.name !== action.payload.layerName);
     default:
       return state;
   }

--- a/ui/src/views/map/utils_conversion.test.ts
+++ b/ui/src/views/map/utils_conversion.test.ts
@@ -1,0 +1,33 @@
+import { CHtoWGS, WGStoCH } from "./utils_conversion";
+
+describe("Coordinate Conversion Tests", () => {
+  test("Convert WGS to CH and back to WGS", () => {
+    const lat = 46.95108; // Example latitude
+    const lng = 7.43864; // Example longitude
+
+    // Convert WGS to CH
+    const [chY, chX] = WGStoCH(lat, lng);
+
+    // Convert CH back to WGS
+    const [convertedLng, convertedLat] = CHtoWGS(chY, chX);
+
+    // Check if the converted coordinates are close to the original
+    expect(convertedLat).toBeCloseTo(lat, 5);
+    expect(convertedLng).toBeCloseTo(lng, 5);
+  });
+
+  test("Convert CH to WGS and back to CH", () => {
+    const chY = 600000; // Example CH y coordinate
+    const chX = 200000; // Example CH x coordinate
+
+    // Convert CH to WGS
+    const [lng, lat] = CHtoWGS(chY, chX);
+
+    // Convert WGS back to CH
+    const [convertedChY, convertedChX] = WGStoCH(lat, lng);
+
+    // Check if the converted coordinates are close to the original
+    expect(convertedChY).toBeCloseTo(chY, 0);
+    expect(convertedChX).toBeCloseTo(chX, 0);
+  });
+});

--- a/ui/src/views/map/utils_conversion.ts
+++ b/ui/src/views/map/utils_conversion.ts
@@ -1,0 +1,104 @@
+export const WGStoCH = (lat: number, lng: number) => {
+  return [WGStoCHy(lat, lng), WGStoCHx(lat, lng)];
+};
+
+// Convert WGS lat/lng (° dec) to CH x
+const WGStoCHx = (lat: number, lng: number) => {
+  // Convert decimal degrees to sexagesimal seconds
+  lat = DECtoSEX(lat);
+  lng = DECtoSEX(lng);
+
+  // Auxiliary values (% Bern)
+  const lat_aux = (lat - 169028.66) / 10000;
+  const lng_aux = (lng - 26782.5) / 10000;
+
+  // Process X
+  const x =
+    200147.07 +
+    308807.95 * lat_aux +
+    3745.25 * Math.pow(lng_aux, 2) +
+    76.63 * Math.pow(lat_aux, 2) -
+    194.56 * Math.pow(lng_aux, 2) * lat_aux +
+    119.79 * Math.pow(lat_aux, 3);
+
+  return x;
+};
+
+// Convert WGS lat/lng (° dec) to CH y
+const WGStoCHy = (lat: number, lng: number) => {
+  // Convert decimal degrees to sexagesimal seconds
+  lat = DECtoSEX(lat);
+  lng = DECtoSEX(lng);
+
+  // Auxiliary values (% Bern)
+  const lat_aux = (lat - 169028.66) / 10000;
+  const lng_aux = (lng - 26782.5) / 10000;
+
+  // Process Y
+  const y =
+    600072.37 +
+    211455.93 * lng_aux -
+    10938.51 * lng_aux * lat_aux -
+    0.36 * lng_aux * Math.pow(lat_aux, 2) -
+    44.54 * Math.pow(lng_aux, 3);
+
+  return y;
+};
+
+export const CHtoWGS = (y: number, x: number) => {
+  return [CHtoWGSlng(y, x), CHtoWGSlat(y, x)];
+};
+
+// Convert CH y/x to WGS lat
+const CHtoWGSlat = (y: number, x: number) => {
+  // Converts military to civil and to unit = 1000km
+  // Auxiliary values (% Bern)
+  const y_aux = (y - 600000) / 1000000;
+  const x_aux = (x - 200000) / 1000000;
+
+  // Process lat
+  let lat =
+    16.9023892 +
+    3.238272 * x_aux -
+    0.270978 * Math.pow(y_aux, 2) -
+    0.002528 * Math.pow(x_aux, 2) -
+    0.0447 * Math.pow(y_aux, 2) * x_aux -
+    0.014 * Math.pow(x_aux, 3);
+
+  // Unit 10000" to 1 " and converts seconds to degrees (dec)
+  lat = (lat * 100) / 36;
+
+  return lat;
+};
+
+// Convert CH y/x to WGS lng
+const CHtoWGSlng = (y: number, x: number) => {
+  // Converts military to civil and	to unit = 1000km
+  // Auxiliary values (% Bern)
+  const y_aux = (y - 600000) / 1000000;
+  const x_aux = (x - 200000) / 1000000;
+
+  // Process lng
+  let lng =
+    2.6779094 +
+    4.728982 * y_aux +
+    0.791484 * y_aux * x_aux +
+    0.1306 * y_aux * Math.pow(x_aux, 2) -
+    0.0436 * Math.pow(y_aux, 3);
+
+  // Unit 10000" to 1 " and converts seconds to degrees (dec)
+  lng = (lng * 100) / 36;
+
+  return lng;
+};
+
+// Convert angle in decimal degrees to sexagesimal seconds
+const DECtoSEX = (angle: number) => {
+  // Extract DMS
+  const deg = Math.floor(angle);
+  const min = Math.floor((angle - deg) * 60);
+  const sec = ((angle - deg) * 60 - min) * 60;
+
+  // Result sexagesimal seconds
+  return sec + min * 60.0 + deg * 3600.0;
+};


### PR DESCRIPTION
This allows layers to be added to the map from remote WMS servers. There is a small pre-selected list of servers but custom ones can be entered.

This also organizes the map StyleController and the LayerController as panels to have a similar design pattern in place.

![image](https://github.com/user-attachments/assets/471220d6-2607-4ae9-bf1e-c125e3f80395)


closes #577 