### PR TITLE
feat(map): add legend for WMS layers

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://api.mapbox.com; connect-src 'self' ws://* wss://* https://*;" />
+    content="default-src 'self'; img-src 'self' data: https://* http://*; style-src 'self' 'unsafe-inline'; style-src-attr 'self' 'unsafe-inline'; child-src 'none'; worker-src 'self' blob:; script-src 'self' 'wasm-unsafe-eval'; script-src-elem 'self' https://api.mapbox.com; connect-src 'self' ws://* wss://* https://*;" />
   <meta name="description" content="SitRep" />
   <link rel="icon" href="/favicon-48x48.ico" sizes="48x48" />
   <link rel="icon" href="/favicon.ico" sizes="64x64" />

--- a/ui/src/views/map/LayerContext.tsx
+++ b/ui/src/views/map/LayerContext.tsx
@@ -23,6 +23,7 @@ export interface WMSLayer {
   server: string;
   opacity: number;
   isVisible: boolean;
+  legendURL?: string;
 }
 
 export interface LayerState {

--- a/ui/src/views/map/controls/ActiveLayersControl.tsx
+++ b/ui/src/views/map/controls/ActiveLayersControl.tsx
@@ -3,17 +3,19 @@ import {
   faEye,
   faEyeSlash,
   faHexagonNodesBolt,
+  faInfoCircle,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
 import type React from "react";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import type { Layer } from "types/layer";
 import { LayerContext, type WMSLayer } from "../LayerContext";
 
 const ActiveLayersControl: React.FC = () => {
   const { state, dispatch } = useContext(LayerContext);
+  const [expandedLayer, setExpandedLayer] = useState<string | null>(null);
 
   const handleVisibilityToggle = (layerName: string, isVisible: boolean) => {
     dispatch({
@@ -35,6 +37,10 @@ const ActiveLayersControl: React.FC = () => {
 
   const handleDeleteLayer = (layerName: string) => {
     dispatch({ type: "REMOVE_WMS_LAYER", payload: { layerName } });
+  };
+
+  const handleInfoToggle = (layerName: string) => {
+    setExpandedLayer(expandedLayer === layerName ? null : layerName);
   };
 
   return (
@@ -61,15 +67,25 @@ const ActiveLayersControl: React.FC = () => {
       {state.wmsLayers.map((layer: WMSLayer) => (
         <div
           key={layer.name}
-          className="panel-block is-align-items-center is-justify-content-space-between"
+          className="panel-block is-align-items-center is-justify-content-space-between is-flex-wrap-wrap"
         >
-          <div className="mr-3 is-align-items-flex-start is-align-content-center is-flex-shrink-2">
+          <div className="mr-3 is-align-items-flex-start is-align-content-center is-flex-shrink-2" style={{ width: "50%" }}>
             <span className="panel-icon" style={{ verticalAlign: "center" }}>
               <FontAwesomeIcon icon={faHexagonNodesBolt} size="lg" />
             </span>
             <span>{layer.title}</span>
           </div>
-          <div className="is-align-items-flex-end is-flex-shrink-0">
+          <div className="is-flex-direction-row	is-align-items-flex-end is-flex-shrink-0 is-flex-wrap-wrap" style={{ width: "45%" }}>
+            {layer.legendURL && (
+              <button
+                className="mr-2 is-align-self-center"
+                type="button"
+                onClick={() => handleInfoToggle(layer.name)}
+              >
+                <FontAwesomeIcon icon={faInfoCircle} />
+              </button>
+            )}
+
             <button
               className="mr-2 is-align-self-center"
               type="button"
@@ -97,6 +113,15 @@ const ActiveLayersControl: React.FC = () => {
               <FontAwesomeIcon icon={faTrash} />
             </button>
           </div>
+          {expandedLayer === layer.name && (
+            <div className="is-align-content-center">
+              <img
+                src={layer.legendURL}
+                alt={`${layer.title}`}
+                style={{ width: "100%" }}
+              />
+            </div>
+          )}
         </div>
       ))
       }

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -129,7 +129,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
     } else if (serverLayersCache[selectedServer]) {
       setLayers(serverLayersCache[selectedServer]);
     }
-  }, [selectedServer, serverLayersCache]);
+  }, [selectedServer, serverLayersCache, i18n.language]);
 
   const handleLayerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const layerName = event.target.value;

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -12,6 +12,7 @@ const FETCH_LAYERS_ERROR = new Error("wmsLayerMenu.errorFetchingLayers");
 type WMSLayerMenuError = typeof NO_LAYERS_FOUND_ERROR | typeof FETCH_LAYERS_ERROR;
 
 interface Layer {
+  legendURL: string | undefined;
   name: string;
   title: string;
   key: string;
@@ -31,16 +32,23 @@ interface WMSLayer {
   Title: string;
   CRS: string[];
   Layer?: WMSLayer[];
+  Style?: {
+    LegendURL?: {
+      OnlineResource: string;
+    }[];
+  }[];
+  legendURL?: string;
 }
 
-const extractLayers = (layer: WMSLayer): WMSLayer[] => {
+const extractLayers = (layer: WMSLayer, server: string): WMSLayer[] => {
   let layers: WMSLayer[] = [];
   if (layer.Layer) {
     for (const subLayer of layer.Layer) {
-      layers = layers.concat(extractLayers(subLayer));
+      layers = layers.concat(extractLayers(subLayer, server));
     }
   } else {
-    layers.push(layer);
+    const legendURL = layer.Style?.[0]?.LegendURL?.[0]?.OnlineResource;
+    layers.push({ ...layer, legendURL: legendURL ? legendURL : undefined });
   }
   return layers;
 };
@@ -71,9 +79,6 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
   const WMS_SERVERS = [
     { name: t("mapview.Gefahrenkarte"), url: `https://geodienste.ch/db/gefahrenkarten_v1_3_0/${language}` },
     { name: "geo.admin.ch", url: "https://wms.geo.admin.ch" },
-    { name: "geo.ur.ch", url: "https://geo.ur.ch/wms" },
-    { name: "sitn.ne.ch", url: "https://sitn.ne.ch/services/wms" },
-    { name: "map.geo.sz.ch", url: "https://map.geo.sz.ch/mapserv_proxy" },
   ];
 
   useEffect(() => {
@@ -86,14 +91,13 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
       setIsLoading(true);
       setError(null);
       fetch(
-        `${selectedServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities`
+        `${selectedServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities&parameterlang=${i18n.language}`
       )
         .then((response) => response.text())
         .then((data) => {
           const parser = new WMSCapabilities();
           const result = parser.read(data);
-          console.log(result);
-          const allLayers = extractLayers(result.Capability.Layer);
+          const allLayers = extractLayers(result.Capability.Layer, selectedServer);
           const layers = allLayers.filter((layer: WMSLayer) => {
             const hasEPSG3857 = layer.CRS?.includes("EPSG:3857") || result.Capability.Layer.CRS?.includes("EPSG:3857");
             return hasEPSG3857;
@@ -101,11 +105,11 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
             name: layer.Name,
             title: layer.Title,
             key: `${layer.Name}-${index}`,
+            legendURL: layer.legendURL,
           })).sort((a, b) => a.title.localeCompare(b.title));
           if (layers.length === 0) {
             throw NO_LAYERS_FOUND_ERROR;
           }
-          console.log("Fetched WMS layers:", layers);
           setLayers(layers);
           setServerLayersCache((prevCache) => ({
             ...prevCache,
@@ -115,7 +119,6 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
         })
         .catch((error) => {
           if (error !== NO_LAYERS_FOUND_ERROR) {
-            console.error("Error fetching WMS layers:", error);
             setError(FETCH_LAYERS_ERROR)
           } else {
             setError(error);
@@ -140,6 +143,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
           title: layer.title,
           opacity: 0.7,
           server: selectedServer,
+          legendURL: layer.legendURL,
         },
       });
       disable();

--- a/ui/src/views/map/reducer.tsx
+++ b/ui/src/views/map/reducer.tsx
@@ -78,6 +78,7 @@ export interface AddWMSLayerAction {
     title: string;
     opacity: number;
     server: string;
+    legendURL?: string;
   };
 }
 
@@ -195,6 +196,7 @@ export const wmsLayersReducer = (
           opacity: action.payload.opacity,
           server: action.payload.server,
           isVisible: true,
+          legendURL: action.payload.legendURL,
         },
       ];
     case "UPDATE_WMS_LAYER_OPACITY":


### PR DESCRIPTION
This adds the referenced legends from the WMS layer description to the layers overview, behind the info icon.

![image](https://github.com/user-attachments/assets/b0caf0b8-c10a-4ed3-85bf-9e7236ad5a5a)

The layers are language specific if the WMS server supports it:

![image](https://github.com/user-attachments/assets/d0e4db2b-18ce-46f7-ac2e-d6dda63a355d)

