### PR TITLE
refactor(map): optimize WMS state handling

### DIFF
--- a/ui/src/i18n/locales/de/translations.json
+++ b/ui/src/i18n/locales/de/translations.json
@@ -40,7 +40,6 @@
     "layer": "Layer",
     "unlock": "Fixierte Signatur lösen",
     "lock": "Signatur fixieren",
-    "Gefahrenkarte": "Gefahrenkarten",
     "wmsLayerMenu": {
       "errorFetchingLayers": "WMS Server konnte nicht erreicht werden oder keine Layer gefunden.",
       "noLayersFound": "Keine kompatiblen Layers gefunden. WMS Server muss EPSG:3857 Projektion unterstützen."

--- a/ui/src/i18n/locales/en/translations.json
+++ b/ui/src/i18n/locales/en/translations.json
@@ -40,7 +40,6 @@
     "layer": "Layer",
     "unlock": "Unlock symbol",
     "lock": "Lock Symbol",
-    "Gefahrenkarte": "Hazard map",
     "wmsLayerMenu": {
       "errorFetchingLayers": "Error fetching layers",
       "noLayersFound": "No compatible layers found. WMS Server must support EPSG:3857 projection."

--- a/ui/src/i18n/locales/fr/translations.json
+++ b/ui/src/i18n/locales/fr/translations.json
@@ -40,7 +40,6 @@
     "layer": "calque",
     "unlock": "Désamarrer le signe",
     "lock": "Verrouiller le signe",
-    "Gefahrenkarte": "Cartes des dangers",
     "wmsLayerMenu": {
       "errorFetchingLayers": "Erreur lors de la récupération des calques.",
       "noLayersFound": "Aucun calque compatible trouvé. Le serveur WMS doit prendre en charge la projection EPSG:3857."

--- a/ui/src/i18n/locales/it/translations.json
+++ b/ui/src/i18n/locales/it/translations.json
@@ -40,7 +40,6 @@
     "layer": "Livello",
     "unlock": "Rilasciare l'allineamento",
     "lock": "Fissare l'allineamento",
-    "Gefahrenkarte": "Carte dei pericoli",
     "wmsLayerMenu": {
       "errorFetchingLayers": "Impossibile raggiungere il server WMS o non sono stati trovati livelli.",
       "noLayersFound": "Nessun livello compatibile trovato. Il server WMS deve supportare la proiezione EPSG:3857."

--- a/ui/src/views/map/ActiveWMSLayers.tsx
+++ b/ui/src/views/map/ActiveWMSLayers.tsx
@@ -4,13 +4,13 @@ import { LayerContext, type WMSLayer } from "./LayerContext";
 
 const ActiveWMSLayers = () => {
   const { state } = useContext(LayerContext);
-  if (!state.wmsLayers) {
+  if (!state.wms.activeLayers) {
     return null;
   }
 
   return (
     <>
-      {state.wmsLayers
+      {state.wms.activeLayers
         .filter((layer: WMSLayer) => layer.isVisible)
         .map((layer: WMSLayer) => (
           <Source

--- a/ui/src/views/map/LayerContext.tsx
+++ b/ui/src/views/map/LayerContext.tsx
@@ -1,6 +1,6 @@
 import type MapboxDraw from "@mapbox/mapbox-gl-draw";
 import type React from "react";
-import { createContext, useReducer } from "react";
+import { createContext, useReducer, type Reducer } from "react";
 import type { Layer } from "types/layer";
 import {
   type LayersAction,
@@ -8,7 +8,7 @@ import {
   drawReducer,
   layersReducer,
   selectedFeatureReducer,
-  wmsLayersReducer,
+  wmsReducer,
 } from "./reducer";
 
 export type SelectedFeatureState = string | undefined;
@@ -16,6 +16,7 @@ export type LayersState = Layer[];
 export type ActiveLayerState = string | undefined;
 export type DrawState = MapboxDraw | undefined;
 export type WMSLayersState = WMSLayer[];
+export type WMSServerLayersCacheState = Record<string, WMSLayer[]>;
 
 export interface WMSLayer {
   name: string;
@@ -26,12 +27,25 @@ export interface WMSLayer {
   legendURL?: string;
 }
 
+export interface WMSServer {
+  name: string;
+  url: string;
+  language?: string;
+}
+
+export interface WMSState {
+  activeLayers: WMSLayersState;
+  availableLayers: WMSServerLayersCacheState;
+  currentServer: string;
+  servers: WMSServer[];
+}
+
 export interface LayerState {
   layers: LayersState;
   activeLayer: string | undefined;
   selectedFeature: SelectedFeatureState;
   draw: DrawState;
-  wmsLayers: WMSLayersState;
+  wms: WMSState;
 }
 
 const initialState: LayerState = {
@@ -39,7 +53,18 @@ const initialState: LayerState = {
   activeLayer: undefined,
   selectedFeature: undefined,
   draw: undefined,
-  wmsLayers: [],
+  wms: {
+    activeLayers: [],
+    availableLayers: {},
+    currentServer: "",
+    servers: [
+      { name: "Hazard Map (geodienste.ch)", url: "https://geodienste.ch/db/gefahrenkarten_v1_3_0/ger", language: "en" },
+      { name: "Gefahrenkarte (geodienste.ch)", url: "https://geodienste.ch/db/gefahrenkarten_v1_3_0/ger", language: "de" },
+      { name: "Cartes des dangers (geodienste.ch)", url: "https://geodienste.ch/db/gefahrenkarten_v1_3_0/fra", language: "fr" },
+      { name: "Carte dei pericoli (geodienste.ch)", url: "https://geodienste.ch/db/gefahrenkarten_v1_3_0/ita", language: "it" },
+      { name: "geo.admin.ch", url: "https://wms.geo.admin.ch" },
+    ],
+  },
 };
 
 const LayerContext = createContext<{
@@ -50,15 +75,15 @@ const LayerContext = createContext<{
   dispatch: () => null,
 });
 
-const mainReducer = (
-  { layers, activeLayer, selectedFeature, draw, wmsLayers }: LayerState,
+const mainReducer: Reducer<LayerState, LayersAction> = (
+  { layers, activeLayer, selectedFeature, draw, wms }: LayerState,
   action: LayersAction,
 ) => ({
   layers: layersReducer(layers, action),
   activeLayer: activeLayerReducer(activeLayer, action),
   selectedFeature: selectedFeatureReducer(selectedFeature, action),
   draw: drawReducer(draw, action),
-  wmsLayers: wmsLayersReducer(wmsLayers, action),
+  wms: wmsReducer(wms, action),
 });
 
 const LayersProvider = ({ children }: { children: React.ReactNode }) => {

--- a/ui/src/views/map/controls/ActiveLayersControl.tsx
+++ b/ui/src/views/map/controls/ActiveLayersControl.tsx
@@ -64,7 +64,7 @@ const ActiveLayersControl: React.FC = () => {
           </div>
         </div>
       ))}
-      {state.wmsLayers.map((layer: WMSLayer) => (
+      {state.wms.activeLayers.map((layer: WMSLayer) => (
         <div
           key={layer.name}
           className="panel-block is-align-items-center is-justify-content-space-between is-flex-wrap-wrap"
@@ -123,8 +123,7 @@ const ActiveLayersControl: React.FC = () => {
             </div>
           )}
         </div>
-      ))
-      }
+      ))}
     </div >
   );
 };

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -234,8 +234,8 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
                 <option value="" disabled>
                   {t("wmsLayerMenu.selectLayer")}
                 </option>
-                {layers.map((layer) => (
-                  <option key={layer.key} value={layer.name}>
+                {layers.map((layer, index) => (
+                  <option key={`${layer.name}-${index}`} value={layer.name}>
                     {layer.title}
                   </option>
                 ))}

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -2,9 +2,8 @@ import classNames from "classnames";
 import type React from "react";
 import { useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { LayerContext } from "../LayerContext";
+import { LayerContext, type WMSLayer as StateLayer, type WMSServer } from "../LayerContext";
 import WMSCapabilities from "ol/format/WMSCapabilities";
-
 
 const NO_LAYERS_FOUND_ERROR = new Error("wmsLayerMenu.noLayersFound");
 const FETCH_LAYERS_ERROR = new Error("wmsLayerMenu.errorFetchingLayers");
@@ -15,7 +14,9 @@ interface Layer {
   legendURL: string | undefined;
   name: string;
   title: string;
+  server: string;
   key: string;
+  crs: string[];
 }
 
 const getBaseDomain = (url: string) => {
@@ -27,11 +28,11 @@ const getBaseDomain = (url: string) => {
   }
 };
 
-interface WMSLayer {
+interface WMSCapabilitiesLayer {
   Name: string;
   Title: string;
   CRS: string[];
-  Layer?: WMSLayer[];
+  Layer?: WMSCapabilitiesLayer[];
   Style?: {
     LegendURL?: {
       OnlineResource: string;
@@ -40,81 +41,77 @@ interface WMSLayer {
   legendURL?: string;
 }
 
-const extractLayers = (layer: WMSLayer, server: string): WMSLayer[] => {
-  let layers: WMSLayer[] = [];
+const extractLayers = (layer: WMSCapabilitiesLayer, server: string): Layer[] => {
+  let layers: Layer[] = [];
   if (layer.Layer) {
     for (const subLayer of layer.Layer) {
       layers = layers.concat(extractLayers(subLayer, server));
     }
   } else {
     const legendURL = layer.Style?.[0]?.LegendURL?.[0]?.OnlineResource;
-    layers.push({ ...layer, legendURL: legendURL ? legendURL : undefined });
+    layers.push({
+      ...layer,
+      legendURL: legendURL ? legendURL : undefined,
+      name: layer.Name,
+      title: layer.Title,
+      server,
+      key: `${layer.Name}-${server}`,
+      crs: layer.CRS,
+    });
   }
   return layers;
 };
 
 const WMSLayerMenu = (props: { disable: () => void }) => {
-  const [layers, setLayers] = useState<Layer[]>([]);
+  const [layers, setLayers] = useState<StateLayer[]>([]);
   const [selectedLayer, setSelectedLayer] = useState<string | null>(null);
-  const [selectedServer, setSelectedServer] = useState<string>("");
   const [customServer, setCustomServer] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [serverLayersCache, setServerLayersCache] = useState<
-    Record<string, Layer[]>
-  >({});
   const [error, setError] = useState<WMSLayerMenuError | null>(null);
-  const { dispatch } = useContext(LayerContext);
+  const { dispatch, state } = useContext(LayerContext);
   const { disable } = props;
   const { t, i18n } = useTranslation();
 
-  const languageMap: Record<string, string> = {
-    de: "ger",
-    fr: "fra",
-    it: "ita",
-    en: "ger",
-  };
-
-  const language = languageMap[i18n.language] || "ger";
-
-  const WMS_SERVERS = [
-    { name: t("mapview.Gefahrenkarte"), url: `https://geodienste.ch/db/gefahrenkarten_v1_3_0/${language}` },
-    { name: "geo.admin.ch", url: "https://wms.geo.admin.ch" },
-  ];
+  useEffect(() => {
+    const initialServer = state.wms.servers[0].url;
+    dispatch({ type: "SET_WMS_SERVER", payload: { server: initialServer } });
+  }, [state.wms.servers, dispatch]);
 
   useEffect(() => {
-    const initialServer = WMS_SERVERS[0].url;
-    setSelectedServer(initialServer);
-  }, [WMS_SERVERS[0].url]);
-
-  useEffect(() => {
-    if (selectedServer && !serverLayersCache[selectedServer]) {
+    if (state.wms.currentServer && !state.wms.availableLayers[state.wms.currentServer]) {
       setIsLoading(true);
       setError(null);
       fetch(
-        `${selectedServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities&parameterlang=${i18n.language}`
+        `${state.wms.currentServer}?&SERVICE=WMS&VERSION=1.3.0&request=getCapabilities&parameterlang=${i18n.language}`
       )
         .then((response) => response.text())
         .then((data) => {
           const parser = new WMSCapabilities();
           const result = parser.read(data);
-          const allLayers = extractLayers(result.Capability.Layer, selectedServer);
-          const layers = allLayers.filter((layer: WMSLayer) => {
-            const hasEPSG3857 = layer.CRS?.includes("EPSG:3857") || result.Capability.Layer.CRS?.includes("EPSG:3857");
+          const allLayers = extractLayers(result.Capability.Layer, state.wms.currentServer);
+          const layers = allLayers.filter((layer: Layer) => {
+            const hasEPSG3857 = layer.crs?.includes("EPSG:3857") || result.Capability.Layer.CRS?.includes("EPSG:3857");
             return hasEPSG3857;
-          }).map((layer: WMSLayer, index: number) => ({
-            name: layer.Name,
-            title: layer.Title,
-            key: `${layer.Name}-${index}`,
+          }).map((layer: Layer, index: number) => ({
+            name: layer.name,
+            title: layer.title,
+            key: `${layer.name}-${index}`,
             legendURL: layer.legendURL,
+            isVisible: true,
+            opacity: 1,
+            server: state.wms.currentServer,
           })).sort((a, b) => a.title.localeCompare(b.title));
           if (layers.length === 0) {
             throw NO_LAYERS_FOUND_ERROR;
           }
           setLayers(layers);
-          setServerLayersCache((prevCache) => ({
-            ...prevCache,
-            [selectedServer]: layers,
-          }));
+          dispatch({
+            type: "SET_WMS_SERVER_LAYERS_CACHE",
+            payload: {
+              server: state.wms.currentServer,
+              layers: layers
+            },
+          });
           setIsLoading(false);
         })
         .catch((error) => {
@@ -126,10 +123,16 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
           setLayers([]);
           setIsLoading(false);
         });
-    } else if (serverLayersCache[selectedServer]) {
-      setLayers(serverLayersCache[selectedServer]);
+    } else if (state.wms.availableLayers[state.wms.currentServer]) {
+      const layers = state.wms.availableLayers[state.wms.currentServer].map((layer: StateLayer) => ({
+        ...layer,
+        isVisible: true,
+        opacity: 1,
+        server: state.wms.currentServer,
+      }));
+      setLayers(layers);
     }
-  }, [selectedServer, serverLayersCache, i18n.language]);
+  }, [state.wms.currentServer, state.wms.availableLayers, i18n.language, dispatch]);
 
   const handleLayerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const layerName = event.target.value;
@@ -142,7 +145,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
           layerName: layerName,
           title: layer.title,
           opacity: 0.7,
-          server: selectedServer,
+          server: state.wms.currentServer,
           legendURL: layer.legendURL,
         },
       });
@@ -151,7 +154,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
   };
 
   const handleServerSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setSelectedServer(event.target.value);
+    dispatch({ type: "SET_WMS_SERVER", payload: { server: event.target.value } });
     setCustomServer("");
   };
 
@@ -164,11 +167,15 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
   const handleCustomServerSubmit = () => {
     if (customServer) {
       const baseDomain = getBaseDomain(customServer);
-      setSelectedServer(customServer);
-      WMS_SERVERS.push({ name: baseDomain, url: customServer });
+      dispatch({ type: "SET_WMS_SERVER", payload: { server: customServer } });
+      dispatch({ type: "ADD_CUSTOM_WMS_SERVER", payload: { server: { name: baseDomain, url: customServer } } });
       setCustomServer("");
     }
   };
+
+  const filteredServers = state.wms.servers.filter(
+    (server) => !server.language || server.language === i18n.language
+  );
 
   return (
     <div className="panel-block is-align-items-flex-start is-justify-content-space-between is-flex-direction-column">
@@ -178,9 +185,9 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
             <select
               className="mb-2"
               onChange={handleServerSelect}
-              value={selectedServer}
+              value={state.wms.currentServer}
             >
-              {WMS_SERVERS.map((server) => (
+              {filteredServers.map((server: WMSServer) => (
                 <option key={server.url} value={server.url}>
                   {server.name}
                 </option>
@@ -190,7 +197,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
           </div>
         </div>
 
-        {selectedServer === "" && (
+        {state.wms.currentServer === "" && (
           <div className="column">
             <input
               type="text"
@@ -209,7 +216,7 @@ const WMSLayerMenu = (props: { disable: () => void }) => {
             </button>
           </div>
         )}
-        {selectedServer && (
+        {state.wms.currentServer && (
           <div className="column">
             <div
               className={classNames({

--- a/ui/src/views/map/reducer.tsx
+++ b/ui/src/views/map/reducer.tsx
@@ -6,7 +6,9 @@ import type {
   DrawState,
   LayersState,
   SelectedFeatureState,
-  WMSLayersState,
+  WMSLayer,
+  WMSState,
+  WMSServer,
 } from "./LayerContext";
 
 // All valid actions
@@ -22,7 +24,10 @@ export type LayersAction =
   | UpdateWMSLayerOpacityAction
   | ToggleLayerVisibilityAction
   | UpdateLayerOpacityAction
-  | RemoveWMSLayerAction;
+  | RemoveWMSLayerAction
+  | SetWMSServerAction
+  | SetWMSServerLayersCacheAction
+  | AddCustomWMSServerAction;
 
 export interface SetLayerAction {
   type: "SET_LAYERS";
@@ -113,6 +118,28 @@ export interface RemoveWMSLayerAction {
   };
 }
 
+export interface SetWMSServerAction {
+  type: "SET_WMS_SERVER";
+  payload: {
+    server: string;
+  };
+}
+
+export interface SetWMSServerLayersCacheAction {
+  type: "SET_WMS_SERVER_LAYERS_CACHE";
+  payload: {
+    server: string;
+    layers: WMSLayer[];
+  };
+}
+
+export interface AddCustomWMSServerAction {
+  type: "ADD_CUSTOM_WMS_SERVER";
+  payload: {
+    server: WMSServer;
+  };
+}
+
 export const layersReducer = (state: LayersState, action: LayersAction) => {
   switch (action.type) {
     case "SET_LAYERS":
@@ -179,40 +206,67 @@ export const drawReducer = (state: DrawState, action: LayersAction) => {
   }
 };
 
-export const wmsLayersReducer = (
-  state: WMSLayersState,
-  action: LayersAction,
-) => {
+export const wmsReducer = (state: WMSState, action: LayersAction) => {
   switch (action.type) {
     case "ADD_WMS_LAYER":
-      if (state.some((layer) => layer.name === action.payload.layerName)) {
+      if (state.activeLayers.some((layer) => layer.name === action.payload.layerName)) {
         return state;
       }
-      return [
+      return {
         ...state,
-        {
-          name: action.payload.layerName,
-          title: action.payload.title,
-          opacity: action.payload.opacity,
-          server: action.payload.server,
-          isVisible: true,
-          legendURL: action.payload.legendURL,
-        },
-      ];
+        activeLayers: [
+          ...state.activeLayers,
+          {
+            name: action.payload.layerName,
+            title: action.payload.title,
+            opacity: action.payload.opacity,
+            server: action.payload.server,
+            isVisible: true,
+            legendURL: action.payload.legendURL,
+          },
+        ],
+      };
     case "UPDATE_WMS_LAYER_OPACITY":
-      return state.map((layer) =>
-        layer.name === action.payload.layerName
-          ? { ...layer, opacity: action.payload.opacity }
-          : layer,
-      );
+      return {
+        ...state,
+        activeLayers: state.activeLayers.map((layer) =>
+          layer.name === action.payload.layerName
+            ? { ...layer, opacity: action.payload.opacity }
+            : layer,
+        ),
+      };
     case "TOGGLE_LAYER_VISIBILITY":
-      return state.map((layer) =>
-        layer.name === action.payload.layerName
-          ? { ...layer, isVisible: action.payload.isVisible }
-          : layer,
-      );
+      return {
+        ...state,
+        activeLayers: state.activeLayers.map((layer) =>
+          layer.name === action.payload.layerName
+            ? { ...layer, isVisible: action.payload.isVisible }
+            : layer,
+        ),
+      };
     case "REMOVE_WMS_LAYER":
-      return state.filter((layer) => layer.name !== action.payload.layerName);
+      return {
+        ...state,
+        activeLayers: state.activeLayers.filter((layer) => layer.name !== action.payload.layerName),
+      };
+    case "SET_WMS_SERVER":
+      return {
+        ...state,
+        currentServer: action.payload.server,
+      };
+    case "SET_WMS_SERVER_LAYERS_CACHE":
+      return {
+        ...state,
+        availableLayers: {
+          ...state.availableLayers,
+          [action.payload.server]: action.payload.layers,
+        },
+      };
+    case "ADD_CUSTOM_WMS_SERVER":
+      return {
+        ...state,
+        servers: [...state.servers, action.payload.server],
+      };
     default:
       return state;
   }


### PR DESCRIPTION
Push WMS state to LayerContext instead of keeping it in WMSLayerMenu. This optimizes that the GetCapabilities and layer parsing only has to be done once per server instead of every remount / reselection of the WMS server.