### PR TITLE
feat(map): persist WMS layer state locally in localStorage

### DIFF
--- a/ui/src/views/map/LayerContext.tsx
+++ b/ui/src/views/map/LayerContext.tsx
@@ -100,8 +100,13 @@ const LayersProvider = ({ children }: { children: React.ReactNode }) => {
     initialState,
     (initialState) => {
       // get the WMS state from localStorage if it exists
-      const wms = localStorage.getItem(wmsLocalStorageKey);
-      return wms ? { ...initialState, wms: JSON.parse(wms) } : initialState;
+      try {
+        const wms = localStorage.getItem(wmsLocalStorageKey);
+        return wms ? { ...initialState, wms: JSON.parse(wms) } : initialState;
+      } catch (error) {
+        console.error("Failed to parse WMS state from localStorage:", error);
+        return initialState;
+      }
     }
   );
 

--- a/ui/src/views/map/LayerContext.tsx
+++ b/ui/src/views/map/LayerContext.tsx
@@ -1,6 +1,6 @@
 import type MapboxDraw from "@mapbox/mapbox-gl-draw";
 import type React from "react";
-import { createContext, useReducer, type Reducer } from "react";
+import { createContext, useEffect, useReducer, type Reducer } from "react";
 import type { Layer } from "types/layer";
 import {
   type LayersAction,
@@ -91,8 +91,24 @@ const mainReducer: Reducer<LayerState, LayersAction> = (
   wms: wmsReducer(wms, action),
 });
 
+// This key is used to store the WMS state in localStorage
+const wmsLocalStorageKey = "wmsLayersState";
+
 const LayersProvider = ({ children }: { children: React.ReactNode }) => {
-  const [state, dispatch] = useReducer(mainReducer, initialState);
+  const [state, dispatch] = useReducer(
+    mainReducer,
+    initialState,
+    (initialState) => {
+      // get the WMS state from localStorage if it exists
+      const wms = localStorage.getItem(wmsLocalStorageKey);
+      return wms ? { ...initialState, wms: JSON.parse(wms) } : initialState;
+    }
+  );
+
+  // store the WMS state in localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem(wmsLocalStorageKey, JSON.stringify(state.wms));
+  }, [state.wms]);
 
   return (
     <LayerContext.Provider value={{ state, dispatch }}>


### PR DESCRIPTION
Details:
* store WMS layer state (selected layers, servers, etc) locally in the localStorage.
* previously, every full-rerender of the map routes created a new layercontext which in turn cleared the selected WMS layers and servers.
* WMS layers we want to keep locally persisted and not centrally pushed as adding a new layer or server would propagate to all subscribed clients otherwise.