### PR TITLE
fix(ui): properly show spinner when loading data initially

### DIFF
--- a/ui/src/views/incident/Dashboard.tsx
+++ b/ui/src/views/incident/Dashboard.tsx
@@ -34,7 +34,7 @@ function Dashboard() {
   if (error)
     return <div className="notification is-danger">{error.message}</div>;
 
-  if (loading) return <Spinner />;
+  if (loading && !data) return <Spinner />;
 
   return (
     <div>

--- a/ui/src/views/incident/List.tsx
+++ b/ui/src/views/incident/List.tsx
@@ -37,7 +37,7 @@ function List() {
 
 	if (error)
 		return <div className="notification is-danger">{error.message}</div>;
-	if (loading) return <Spinner />;
+	if (loading && !data) return <Spinner />;
 
 	return (
 		<div>

--- a/ui/src/views/journal/List.tsx
+++ b/ui/src/views/journal/List.tsx
@@ -73,7 +73,7 @@ function List(props: {
     );
   }
 
-  if (loading) return <Spinner />;
+  if (loading && !data) return <Spinner />;
   const divisions: Division[] = data?.journalsByPk?.incident?.divisions?.flat() || [];
 
   const messages =

--- a/ui/src/views/journal/Overview.tsx
+++ b/ui/src/views/journal/Overview.tsx
@@ -41,7 +41,7 @@ function Overview() {
   if (error)
     return <div className="notification is-danger">{error.message}</div>;
 
-  if (loading) return <Spinner />;
+  if (loading && !data) return <Spinner />;
 
   if (!data || !(data.incidents.length === 1))
     return (


### PR DESCRIPTION
Since the apollo v4 migration, we show a constant rerender when fetching new messages with the pollers. This makes sure to only show the spinner when we are initially fetching the data