### PR TITLE
fix(hasura): make sure users work on triage

### DIFF
--- a/Dockerfile.hasura
+++ b/Dockerfile.hasura
@@ -1,4 +1,4 @@
-FROM docker.io/hasura/graphql-engine:v2.48.1-ce.cli-migrations-v3.ubi@sha256:945f352923f51c0fefa9a84d5f286afaf7b61414b0d5a71e49ae4302f76d7a3d
+FROM docker.io/hasura/graphql-engine:v2.48.6-ce.cli-migrations-v3.ubi@sha256:945f352923f51c0fefa9a84d5f286afaf7b61414b0d5a71e49ae4302f76d7a3d
 COPY hasura/migrations /hasura-migrations
 COPY hasura/metadata /hasura-metadata
 ENV HASURA_GRAPHQL_EXPERIMENTAL_FEATURES=naming_convention

--- a/hasura/migrations/Postgres/1763382566880_change_user_trigger_for_updates/down.sql
+++ b/hasura/migrations/Postgres/1763382566880_change_user_trigger_for_updates/down.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE TRIGGER trigger_insert_user
+  BEFORE INSERT ON messages
+  FOR EACH ROW
+  EXECUTE PROCEDURE insert_user_for_messages();

--- a/hasura/migrations/Postgres/1763382566880_change_user_trigger_for_updates/up.sql
+++ b/hasura/migrations/Postgres/1763382566880_change_user_trigger_for_updates/up.sql
@@ -1,0 +1,4 @@
+CREATE OR REPLACE TRIGGER trigger_insert_user
+  BEFORE INSERT OR UPDATE ON messages
+  FOR EACH ROW
+  EXECUTE PROCEDURE insert_user_for_messages();


### PR DESCRIPTION
Details:
* currently user updates via triggers were only done for inserts. This caused users being shown an error message when they did never write a message first when attempting to update a message or triage a message.