### PR TITLE
chore(security): address 4 CVEs in jsPDF with upgrade from 4.0.0 to 4.1.0

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -119,7 +119,7 @@
   "resolutions": {
     "brace-expansion": "2.0.2",
     "dompurify": "3.3.0",
-    "jspdf": "^4.0.0",
+    "jspdf": "^4.1.0",
     "maplibre-gl": "5.17.0",
     "sharp": "^0.34.5",
     "js-yaml": "^4.1.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -9335,14 +9335,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jspdf@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "jspdf@npm:4.0.0"
+"jspdf@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "jspdf@npm:4.1.0"
   dependencies:
     "@babel/runtime": "npm:^7.28.4"
     canvg: "npm:^3.0.11"
     core-js: "npm:^3.6.0"
-    dompurify: "npm:^3.2.4"
+    dompurify: "npm:^3.3.1"
     fast-png: "npm:^6.2.0"
     fflate: "npm:^0.8.1"
     html2canvas: "npm:^1.0.0-rc.5"
@@ -9355,7 +9355,7 @@ __metadata:
       optional: true
     html2canvas:
       optional: true
-  checksum: 10/c62d3ff32b450e184e8d535dfd71fccd38b457b1be3886839d18a8975f077f3f16b0b5fd7dd2f75416dc6a324608488cd3d5a20fb8ac7e44341adbdbbff20301
+  checksum: 10/07ca8deec968db23acf0747b4dc6ea6896a05cb4b0d4fc13ddd63b55e3165f66c2e80fc1d8383e162310a0e7af12382fb7f23c4d517c035d3a981f816da1b4bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This addresses the following CVEs (2 high, 2 moderate):
* https://github.com/f-eld-ch/sitrep/security/dependabot/90
* https://github.com/f-eld-ch/sitrep/security/dependabot/89
* https://github.com/f-eld-ch/sitrep/security/dependabot/88
* https://github.com/f-eld-ch/sitrep/security/dependabot/87