### PR TITLE
feat(journal): add human readable message number

### DIFF
--- a/ui/src/types/journal.ts
+++ b/ui/src/types/journal.ts
@@ -21,6 +21,7 @@ export enum Medium {
 
 export interface Message {
   id: string;
+  number?: number;
   content: string;
   sender: string;
   senderDetail: string;

--- a/ui/src/views/journal/List.tsx
+++ b/ui/src/views/journal/List.tsx
@@ -92,6 +92,32 @@ function List(props: {
           message.divisions?.find((d) => d.division.name === assignmentFilter),
       ) || [];
 
+  // assign the sequence to the messages for stable sorting and ID generation
+  const stableOrderByCreatedAt = <T extends { createdAt: Date; id?: string }>(
+    msgs: T[],
+  ): T[] =>
+    msgs
+      .map((m, idx) => ({ m, idx }))
+      .sort((a, b) => {
+        const tA = new Date(a.m.createdAt);
+        const tB = new Date(b.m.createdAt);
+        if (tA !== tB) return tA.getTime() - tB.getTime();
+        if (a.m.id && b.m.id)
+          return a.m.id < b.m.id ? -1 : a.m.id > b.m.id ? 1 : 0;
+        return a.idx - b.idx;
+      })
+      .map(({ m }) => m);
+
+  const messagesWithNumber = stableOrderByCreatedAt(messages).map((m, i) => ({
+    ...m,
+    number: i + 1,
+  }));
+
+  // sort the message again with the message time stamp
+  messagesWithNumber.sort(
+    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
+  );
+
   return (
     <>
       <div className="is-hidden-print">
@@ -197,7 +223,7 @@ function List(props: {
       <div className="columns is-multiline is-gapless">
         {data && (
           <MemoMessages
-            messages={messages}
+            messages={messagesWithNumber}
             divisions={divisions}
             showControls={props.showControls}
             setTriageMessage={props.setTriageMessage}
@@ -208,7 +234,7 @@ function List(props: {
       <div style={{ display: "none" }}>
         <MessageTable
           ref={tableRef}
-          messages={messages}
+          messages={messagesWithNumber}
           triageFilter={triageFilter}
           priorityFilter={priorityFilter}
           assignmentFilter={assignmentFilter}

--- a/ui/src/views/journal/List.tsx
+++ b/ui/src/views/journal/List.tsx
@@ -90,33 +90,12 @@ function List(props: {
         (message) =>
           assignmentFilter === "all" ||
           message.divisions?.find((d) => d.division.name === assignmentFilter),
+      )
+      .sort(stableOrderByCreatedAt)
+      .map((m, i) => ({ ...m, number: i + 1 }))
+      .sort(
+        (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
       ) || [];
-
-  // assign the sequence to the messages for stable sorting and ID generation
-  const stableOrderByCreatedAt = <T extends { createdAt: Date; id?: string }>(
-    msgs: T[],
-  ): T[] =>
-    msgs
-      .map((m, idx) => ({ m, idx }))
-      .sort((a, b) => {
-        const tA = new Date(a.m.createdAt);
-        const tB = new Date(b.m.createdAt);
-        if (tA !== tB) return tA.getTime() - tB.getTime();
-        if (a.m.id && b.m.id)
-          return a.m.id < b.m.id ? -1 : a.m.id > b.m.id ? 1 : 0;
-        return a.idx - b.idx;
-      })
-      .map(({ m }) => m);
-
-  const messagesWithNumber = stableOrderByCreatedAt(messages).map((m, i) => ({
-    ...m,
-    number: i + 1,
-  }));
-
-  // sort the message again with the message time stamp
-  messagesWithNumber.sort(
-    (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
-  );
 
   return (
     <>
@@ -223,7 +202,7 @@ function List(props: {
       <div className="columns is-multiline is-gapless">
         {data && (
           <MemoMessages
-            messages={messagesWithNumber}
+            messages={messages}
             divisions={divisions}
             showControls={props.showControls}
             setTriageMessage={props.setTriageMessage}
@@ -234,7 +213,7 @@ function List(props: {
       <div style={{ display: "none" }}>
         <MessageTable
           ref={tableRef}
-          messages={messagesWithNumber}
+          messages={messages}
           triageFilter={triageFilter}
           priorityFilter={priorityFilter}
           assignmentFilter={assignmentFilter}
@@ -272,6 +251,17 @@ function Messages(props: {
       })}
     </>
   );
+}
+
+function stableOrderByCreatedAt<T extends { createdAt: Date; id?: string }>(
+  a: T,
+  b: T,
+): number {
+  const tA = new Date(a.createdAt);
+  const tB = new Date(b.createdAt);
+  if (tA.getTime() !== tB.getTime()) return tA.getTime() - tB.getTime();
+  if (a.id && b.id) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  return 0;
 }
 
 export default memo(List);

--- a/ui/src/views/journal/Message.test.tsx
+++ b/ui/src/views/journal/Message.test.tsx
@@ -122,6 +122,46 @@ describe("MessageContainer", () => {
     fireEvent.click(screen.getByTestId("create-task-button"));
   });
 
+  it("does not render message number when number is undefined", () => {
+    render(
+      <MessageContainer
+        id="msg1"
+        message={baseMessage}
+        divisions={divisions}
+        showControls={false}
+      />,
+    );
+    expect(screen.queryByTestId("number-msg1")).not.toBeInTheDocument();
+  });
+
+  it("renders message number when number is defined", () => {
+    render(
+      <MessageContainer
+        id="msg1"
+        message={{ ...baseMessage, number: 42 }}
+        divisions={divisions}
+        showControls={false}
+      />,
+    );
+    expect(screen.getByTestId("number-msg1").textContent).toBe("# 42");
+    expect(screen.getByText("message.id")).toBeInTheDocument();
+  });
+
+  it("renders correct message number for various values", () => {
+    for (const num of [1, 99, 1000]) {
+      const { unmount } = render(
+        <MessageContainer
+          id="msg1"
+          message={{ ...baseMessage, number: num }}
+          divisions={divisions}
+          showControls={false}
+        />,
+      );
+      expect(screen.getByTestId("number-msg1").textContent).toBe(`# ${num}`);
+      unmount();
+    }
+  });
+
   it("renders with random message data (fast-check)", () => {
     fc.assert(
       fc.property(
@@ -151,9 +191,10 @@ describe("MessageContainer", () => {
           updatedAt: fc.date(),
           deletedAt: fc.date(),
           medium: fc.constantFrom(Medium.Email, Medium.Phone, Medium.Radio),
+          number: fc.option(fc.nat(), { nil: undefined }),
         }),
         (msg) => {
-          render(
+          const { unmount } = render(
             <MessageContainer
               id={msg.id}
               message={{ ...msg, divisions: [...msg.divisions] } as Message}
@@ -168,6 +209,16 @@ describe("MessageContainer", () => {
           expect(screen.getByTestId(`receiver-${msg.id}`).textContent).toBe(
             msg.receiver,
           );
+          if (msg.number !== undefined) {
+            expect(
+              screen.getByTestId(`number-${msg.id}`).textContent,
+            ).toBe(`# ${msg.number}`);
+          } else {
+            expect(
+              screen.queryByTestId(`number-${msg.id}`),
+            ).not.toBeInTheDocument();
+          }
+          unmount();
         },
       ),
       { numRuns: 100 },

--- a/ui/src/views/journal/Message.test.tsx
+++ b/ui/src/views/journal/Message.test.tsx
@@ -210,9 +210,9 @@ describe("MessageContainer", () => {
             msg.receiver,
           );
           if (msg.number !== undefined) {
-            expect(
-              screen.getByTestId(`number-${msg.id}`).textContent,
-            ).toBe(`# ${msg.number}`);
+            expect(screen.getByTestId(`number-${msg.id}`).textContent).toBe(
+              `# ${msg.number}`,
+            );
           } else {
             expect(
               screen.queryByTestId(`number-${msg.id}`),

--- a/ui/src/views/journal/Message.tsx
+++ b/ui/src/views/journal/Message.tsx
@@ -177,6 +177,21 @@ const MessageContainer = ({
                   </p>
                 </div>
               </div>
+              {message.number !== undefined && (
+                <div className="level-item has-text-centered is-flex-shrink-0">
+                  <div className="mb-0">
+                    <p className="heading is-size-7 has-text-weight-bold">
+                      {t("message.id")}
+                    </p>
+                    <p
+                      className="subtitle is-size-7"
+                      data-testid={`number-${message.id}`}
+                    >
+                      # {message.number}
+                    </p>
+                  </div>
+                </div>
+              )}
             </nav>
           </div>
           <div className="column is-full" style={{ wordBreak: "break-word" }}>

--- a/ui/src/views/journal/MessageSheet.tsx
+++ b/ui/src/views/journal/MessageSheet.tsx
@@ -82,7 +82,7 @@ const MessageSheet = (
           </tr>
           <tr>
             <th>{t("message.id")}</th>
-            <td colSpan={3}>{message.id}</td>
+            <td colSpan={3}>{message.number ?? message.id}</td>
           </tr>
           <tr>
             <th>{t("message.type")}</th>
@@ -159,6 +159,6 @@ const MessageSheet = (
       </table>
     </div>
   );
-}
+};
 
 export default forwardRef(MessageSheet);

--- a/ui/src/views/map/controls/StyleController.tsx
+++ b/ui/src/views/map/controls/StyleController.tsx
@@ -17,7 +17,9 @@ export const MapStyles: MapStyle[] = [
   },
   {
     name: "Satellit",
-    style: ExpandRelativeURLs(basisKarteImagery as unknown as StyleSpecification),
+    style: ExpandRelativeURLs(
+      basisKarteImagery as unknown as StyleSpecification,
+    ),
   },
 ];
 

--- a/ui/src/views/map/controls/WMSLayerMenu.tsx
+++ b/ui/src/views/map/controls/WMSLayerMenu.tsx
@@ -385,7 +385,11 @@ const WMSLayerMenu = () => {
                     <option value="" disabled>
                       {t("wmsLayerMenu.selectLayer")}
                     </option>
-                    {layers.map((layer) => <option key={layer.name} value={layer.name}>{layer.title}</option>)}
+                    {layers.map((layer) => (
+                      <option key={layer.name} value={layer.name}>
+                        {layer.title}
+                      </option>
+                    ))}
                   </select>
                 </div>
               </div>
@@ -414,6 +418,5 @@ const WMSLayerMenu = () => {
     </>
   );
 };
-
 
 export default WMSLayerMenu;


### PR DESCRIPTION
This adds a human readable message number to the journal list and the message sheet (Meldezettel). The message id is generated via the createdAt timestamp (which is not the same as the message timestamp). So the number is increasing by creation time, even if backdated messages are added.

<img width="1781" height="650" alt="image" src="https://github.com/user-attachments/assets/15cc106a-aa93-40bb-a12e-024684800a90" />
