### PR TITLE
fix(journal): ensure proper sorting of messages by message time

### DIFF
--- a/ui/src/views/journal/List.tsx
+++ b/ui/src/views/journal/List.tsx
@@ -94,7 +94,7 @@ function List(props: {
       .sort(stableOrderByCreatedAt)
       .map((m, i) => ({ ...m, number: i + 1 }))
       .sort(
-        (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
+        (a, b) => new Date(b.time).getTime() - new Date(a.time).getTime(),
       ) || [];
 
   return (


### PR DESCRIPTION
Details:
* messages should always be sorted by message time and not by message number

<img width="1432" height="1420" alt="image" src="https://github.com/user-attachments/assets/ee9bc69b-534d-49b7-b814-87009331c1fc" />
