### PR TITLE
fix(ui): prevent errors from graphql unset variables

### DIFF
--- a/ui/src/utils/IncidentContext.tsx
+++ b/ui/src/utils/IncidentContext.tsx
@@ -70,6 +70,7 @@ const IncidentContextSetter = () => {
   const { loading, data } = useQuery<IncidentDetailsData, IncidentDetailsVars>(GetIncidentDetails, {
     variables: { incidentId: incidentId || "" },
     fetchPolicy: "cache-first",
+    skip: incidentId === undefined,
   });
 
   useEffect(() => {

--- a/ui/src/views/incident/New.tsx
+++ b/ui/src/views/incident/New.tsx
@@ -68,11 +68,7 @@ function IncidentForm(props: { incident: Incident | undefined }) {
       onCompleted(data) {
         navigate(`../${data.insertIncidentsOne.id}/journal/view`);
       },
-      refetchQueries: [
-        { query: GetIncidents },
-        { query: GetIncidentDetails },
-        { query: GetMessageForTriage },
-      ],
+      refetchQueries: [{ query: GetIncidents }, { query: GetIncidentDetails }],
     },
   );
 


### PR DESCRIPTION
Details:
* This prevents some errors returned on the GetIncidentDetails when incidentID is unset. Now those unnecessary queries are just skipped.
* remove `GetMessageForTriage` from the refetch list as the message ID is not always set and thus this query is about to fail. 