### PR TITLE
fix(editor): properly set time to now if not specified otherwise

### DIFF
--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -139,8 +139,12 @@ function Editor() {
   );
 
   const editorReducer = (state: State, action: Action): State => {
+    console.log(action);
     switch (action.type) {
       case "save": {
+        if (state.time === undefined) {
+          return Object.assign({}, state, { time: new Date(), saving: true });
+        }
         return Object.assign({}, state, { saving: true });
       }
       case "save_error": {


### PR DESCRIPTION
Details:
* Set the time explicitly to now for editor messages if explicitly set at saving time