### PR TITLE
fix: improve sender and receiver detail line breaks in journal table

### DIFF
--- a/ui/src/views/journal/Table.tsx
+++ b/ui/src/views/journal/Table.tsx
@@ -55,14 +55,26 @@ const MessageTable = (
             <tr key={message.id}>
               <td>{dayjs(message.time).format("DD.MM.YYYY HH:mm:ss")}</td>
               <td style={cellStyle}>
-                {message.senderDetail
-                  ? `${message.sender}\n(${message.senderDetail})`
-                  : message.sender}
+                {message.senderDetail ? (
+                  <>
+                    {message.sender}
+                    <br />
+                    ({message.senderDetail})
+                  </>
+                ) : (
+                  message.sender
+                )}
               </td>
               <td style={cellStyle}>
-                {message.receiverDetail
-                  ? `${message.receiver}\n(${message.receiverDetail})`
-                  : message.receiver}
+                {message.receiverDetail ? (
+                  <>
+                    {message.receiver}
+                    <br />
+                    ({message.receiverDetail})
+                  </>
+                ) : (
+                  message.receiver
+                )}
               </td>
               <td style={cellStyle}>
                 <div


### PR DESCRIPTION
The journal table rendered sender and receiver details with `\n` inside interpolated strings, which does not produce visible line breaks in HTML. This updates those cells to render the detail on a separate line and adds focused coverage for the table output.

- **Rendering**
  - Replace newline-based string interpolation in `ui/src/views/journal/Table.tsx` with explicit JSX line breaks for `senderDetail` and `receiverDetail`.
  - Preserve the existing single-line rendering when no detail is present.

- **Coverage**
  - Add `ui/src/views/journal/Table.test.tsx` to verify:
    - detail values render in the same cell on a separate HTML line
    - no `<br />` is rendered when detail values are absent

```tsx
<td style={cellStyle}>
  {message.senderDetail ? (
    <>
      {message.sender}
      <br />
      ({message.senderDetail})
    </>
  ) : (
    message.sender
  )}
</td>
```
