### PR TITLE
fix(map): match casualty icons by alias in the label filters

### DIFF
--- a/ui/src/components/babs/iconResolver.ts
+++ b/ui/src/components/babs/iconResolver.ts
@@ -59,6 +59,26 @@ for (const meta of ICONS) {
 }
 
 /**
+ * Every identifier that can denote one of the given icons — alias, bare id, and any legacy
+ * German name mapping to it.
+ *
+ * For use in style *filters*, which compare `properties.icon` literally and so cannot rely
+ * on the `match` expression that resolves `icon-image`. A filter listing only the legacy
+ * names silently stops matching as soon as features start storing aliases, which is how
+ * the casualty-count text layers came to miss every newly placed feature.
+ */
+export function iconIdentifiers(ids: readonly BabsIconId[]): string[] {
+  const identifiers = new Set<string>();
+  for (const id of ids) {
+    identifiers.add(id);
+    const meta = ICONS.find((m) => m.id === id);
+    if (meta) identifiers.add(meta.alias);
+    for (const legacyName of legacyNamesById.get(id) ?? []) identifiers.add(legacyName);
+  }
+  return [...identifiers];
+}
+
+/**
  * Resolves any identifier this application has ever persisted into a catalogue id.
  *
  * Accepts, in order of precedence: a bare catalogue id (`"1101"`), an alias

--- a/ui/src/views/map/casualtyLabels.test.ts
+++ b/ui/src/views/map/casualtyLabels.test.ts
@@ -1,0 +1,109 @@
+import { featureFilter } from "@maplibre/maplibre-gl-style-spec";
+import { aliasFor } from "components/babs/iconResolver";
+import type { LayerProps } from "react-map-gl/maplibre";
+import { describe, expect, it } from "vitest";
+import { createMapStyle } from "./styleGenerator";
+
+/**
+ * The casualty-count icons get their name label placed differently from every other icon:
+ * centred over the symbol for Eingesperrte/Obdachlose, offset to the right for
+ * Tote/Vermisste/Verletzte, and the generic label must skip all five.
+ *
+ * Those three layers select on `properties.icon` with a literal filter, so unlike
+ * `icon-image` there is no `match` expression resolving aliases for them. When features
+ * began storing aliases instead of legacy German names, the filters kept listing only the
+ * legacy names — so every newly placed casualty icon fell through to the generic label.
+ * This pins that all three identifier forms select correctly.
+ */
+
+const CENTRED = "gl-draw-text-special-placement-points-center";
+const RIGHT = "gl-draw-text-special-placement-points-right";
+const GENERIC = "gl-draw-text-name-point";
+
+/** id → the layer that should place its label. */
+const EXPECTED_LAYER: Record<string, string> = {
+  "1304": CENTRED, // Eingesperrte
+  "1303": CENTRED, // Obdachlose
+  "1305": RIGHT, // Tote
+  "1302": RIGHT, // Vermisste
+  "1301": RIGHT, // Verletzte
+};
+
+/** A non-casualty icon, which must take the generic label instead. */
+const ORDINARY_ICON = "1101"; // Beschädigung
+
+const LEGACY_NAMES: Record<string, string> = {
+  "1304": "EingesperrteAbgeschnittene",
+  "1303": "Obdachlose",
+  "1305": "Tote",
+  "1302": "Vermisste",
+  "1301": "Verletzte",
+  "1101": "Beschaedigung",
+};
+
+/** Which of the three text layers accept a point feature carrying this icon. */
+function matchingLayers(icon: string, forDraw: boolean): string[] {
+  const prefix = forDraw ? "user_" : "";
+  const feature = {
+    type: 1 as const,
+    // The layers also require a name and a colour to be present.
+    properties: {
+      [`${prefix}icon`]: icon,
+      [`${prefix}name`]: "12",
+      [`${prefix}color`]: "#ff0000",
+      // Draw-mode filters additionally gate on these.
+      active: "false",
+      meta: "feature",
+      mode: "simple_select",
+    },
+  };
+  return createMapStyle({ forDraw })
+    .filter((layer): layer is LayerProps & { id: string } =>
+      [CENTRED, RIGHT, GENERIC].includes(layer.id ?? ""),
+    )
+    .filter((layer) => {
+      const filter = (layer as { filter?: unknown }).filter;
+      // rootKey is only used to locate errors in messages; any stable label works.
+      return featureFilter(filter as never, `layers.${layer.id}.filter`).filter(
+        { zoom: 14 } as never,
+        feature as never,
+      );
+    })
+    .map((layer) => layer.id);
+}
+
+describe.each([
+  ["draw", true],
+  ["display", false],
+])("casualty label placement (%s mode)", (_mode, forDraw) => {
+  describe.each(Object.entries(EXPECTED_LAYER))("icon %s", (id, expectedLayer) => {
+    // Every identifier a feature could legitimately be carrying.
+    it.each([
+      ["legacy name", LEGACY_NAMES[id]],
+      ["alias", aliasFor(id as never)],
+      ["bare id", id],
+    ])("is placed by its own layer when stored as a %s", (_form, identifier) => {
+      expect(matchingLayers(identifier, forDraw)).toEqual([expectedLayer]);
+    });
+  });
+
+  it("gives an ordinary icon the generic label, and only that", () => {
+    for (const identifier of [
+      LEGACY_NAMES[ORDINARY_ICON],
+      aliasFor(ORDINARY_ICON as never),
+      ORDINARY_ICON,
+    ]) {
+      expect(matchingLayers(identifier, forDraw)).toEqual([GENERIC]);
+    }
+  });
+
+  it("never places two labels on the same feature", () => {
+    // The special layers and the generic one are mutually exclusive by construction; a
+    // feature matching both would be labelled twice, in two different positions.
+    for (const id of [...Object.keys(EXPECTED_LAYER), ORDINARY_ICON]) {
+      for (const identifier of [LEGACY_NAMES[id], aliasFor(id as never), id]) {
+        expect(matchingLayers(identifier, forDraw)).toHaveLength(1);
+      }
+    }
+  });
+});

--- a/ui/src/views/map/styleGenerator.test.ts
+++ b/ui/src/views/map/styleGenerator.test.ts
@@ -1,5 +1,6 @@
 import type { LayerProps } from "react-map-gl/maplibre";
 import { describe, expect, it } from "vitest";
+import { iconIdentifiers } from "components/babs/iconResolver";
 import { Colors } from "components/babs/lineAndZoneTypes";
 import { createMapStyle } from "./styleGenerator";
 
@@ -32,6 +33,18 @@ function layersToMap(layers: LayerProps[]): Record<string, LayerProps> {
  * asserts that `icon-image` is present, on the expected layer, and nowhere else.
  */
 const GENERATED_ICON_IMAGE = "<generated icon-image expression>";
+
+/**
+ * Casualty icons, expanded to every identifier that can denote them.
+ *
+ * Referenced rather than inlined for the same reason as GENERATED_ICON_IMAGE: the list is
+ * derived from the catalogue and the legacy mapping, so writing 15 strings out six times
+ * here would only pin today's catalogue. What these filters actually *do* is verified
+ * behaviourally in casualtyLabels.test.ts, which drives real features through them.
+ */
+const CASUALTIES_CENTRED = iconIdentifiers(["1304", "1303"]);
+const CASUALTIES_RIGHT = iconIdentifiers(["1305", "1302", "1301"]);
+const CASUALTIES_ALL = [...CASUALTIES_CENTRED, ...CASUALTIES_RIGHT];
 
 /** Replaces the generated icon-image expression with the sentinel, non-destructively. */
 function redactIconImage(layer: LayerProps): LayerProps {
@@ -469,7 +482,7 @@ const drawStyle: LayerProps[] = [
       ["==", "meta", "feature"],
       ["has", "user_name"],
       ["has", "user_icon"],
-      ["in", "user_icon", "EingesperrteAbgeschnittene", "Obdachlose"],
+      ["in", "user_icon", ...CASUALTIES_CENTRED],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "user_name"], ""],
@@ -494,7 +507,7 @@ const drawStyle: LayerProps[] = [
       ["==", "meta", "feature"],
       ["has", "user_name"],
       ["has", "user_icon"],
-      ["in", "user_icon", "Tote", "Vermisste", "Verletzte"],
+      ["in", "user_icon", ...CASUALTIES_RIGHT],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "user_name"], ""],
@@ -517,15 +530,7 @@ const drawStyle: LayerProps[] = [
       ["==", "active", "false"],
       ["has", "user_name"],
       ["has", "user_color"],
-      [
-        "!in",
-        "user_icon",
-        "EingesperrteAbgeschnittene",
-        "Obdachlose",
-        "Tote",
-        "Vermisste",
-        "Verletzte",
-      ],
+      ["!in", "user_icon", ...CASUALTIES_ALL],
       ["==", "$type", "Point"],
       ["==", "meta", "feature"],
       ["!=", "mode", "static"],
@@ -945,7 +950,7 @@ const displayStyle: LayerProps[] = [
 
       ["has", "name"],
       ["has", "icon"],
-      ["in", "icon", "EingesperrteAbgeschnittene", "Obdachlose"],
+      ["in", "icon", ...CASUALTIES_CENTRED],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "name"], ""],
@@ -970,7 +975,7 @@ const displayStyle: LayerProps[] = [
       ["==", "$type", "Point"],
       ["has", "name"],
       ["has", "icon"],
-      ["in", "icon", "Tote", "Vermisste", "Verletzte"],
+      ["in", "icon", ...CASUALTIES_RIGHT],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "name"], ""],
@@ -992,7 +997,7 @@ const displayStyle: LayerProps[] = [
       "all",
       ["has", "name"],
       ["has", "color"],
-      ["!in", "icon", "EingesperrteAbgeschnittene", "Obdachlose", "Tote", "Vermisste", "Verletzte"],
+      ["!in", "icon", ...CASUALTIES_ALL],
       ["==", "$type", "Point"],
     ],
     layout: {

--- a/ui/src/views/map/styleGenerator.ts
+++ b/ui/src/views/map/styleGenerator.ts
@@ -1,5 +1,9 @@
 import { type BabsIconId, markerSpriteKey, patternSpriteKey } from "@f-eld-ch/babs-core";
-import { babsImage, legacyIconMatchExpression } from "components/babs/iconResolver";
+import {
+  babsImage,
+  iconIdentifiers,
+  legacyIconMatchExpression,
+} from "components/babs/iconResolver";
 import { ZoneTypes } from "components/babs/lineAndZoneTypes";
 import type { ExpressionSpecification, FilterSpecification } from "maplibre-gl";
 import type { LayerProps } from "react-map-gl/maplibre";
@@ -34,6 +38,27 @@ const SPECIALLY_FILLED_ZONE_NAMES = [
   "Einsatzraum",
   ...FLAT_FILL_ZONES.map((zone) => zone.name),
 ];
+
+/**
+ * Casualty-count icons, whose labels are placed differently from every other icon.
+ *
+ * Listed by catalogue id and expanded to every identifier that can denote them — alias,
+ * id, legacy German name — because these are style *filters* comparing `properties.icon`
+ * literally, with no `match` expression to resolve aliases for them. Before this, the
+ * filters held only the legacy names, so a newly placed casualty icon got the generic
+ * label instead of its own placement.
+ */
+const CASUALTIES_CENTRED = iconIdentifiers([
+  "1304", // Eingesperrte (legacy EingesperrteAbgeschnittene)
+  "1303", // Obdachlose
+]);
+const CASUALTIES_RIGHT = iconIdentifiers([
+  "1305", // Tote
+  "1302", // Vermisste
+  "1301", // Verletzte
+]);
+/** Both groups: the icons the generic name label must skip. */
+const CASUALTIES_ALL = [...CASUALTIES_CENTRED, ...CASUALTIES_RIGHT];
 
 /**
  * Builds a `match` expression keyed on a feature property.
@@ -473,7 +498,7 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
         ["==", "$type", "Point"],
         ["has", `${propPrefix}name`],
         ["has", `${propPrefix}icon`],
-        ["in", `${propPrefix}icon`, "EingesperrteAbgeschnittene", "Obdachlose"],
+        ["in", `${propPrefix}icon`, ...CASUALTIES_CENTRED],
       ]),
       layout: {
         "text-field": ["coalesce", ["get", `${propPrefix}name`], ""],
@@ -496,7 +521,7 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
         ["==", "$type", "Point"],
         ["has", `${propPrefix}name`],
         ["has", `${propPrefix}icon`],
-        ["in", `${propPrefix}icon`, "Tote", "Vermisste", "Verletzte"],
+        ["in", `${propPrefix}icon`, ...CASUALTIES_RIGHT],
       ]),
       layout: {
         "text-field": ["coalesce", ["get", `${propPrefix}name`], ""],
@@ -517,15 +542,7 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
       filter: createFilter([
         ["has", `${propPrefix}name`],
         ["has", `${propPrefix}color`],
-        [
-          "!in",
-          `${propPrefix}icon`,
-          "EingesperrteAbgeschnittene",
-          "Obdachlose",
-          "Tote",
-          "Vermisste",
-          "Verletzte",
-        ],
+        ["!in", `${propPrefix}icon`, ...CASUALTIES_ALL],
         ["==", "$type", "Point"],
       ]),
       layout: {


### PR DESCRIPTION
Fixes a user-visible label regression from #1739.

<!-- screenshot -->

## The bug

The casualty-count icons get their name label placed differently from every other icon: centred over the symbol for Eingesperrte/Obdachlose, offset to the right for Tote/Vermisste/Verletzte, and the generic label skips all five.

Those three text layers select on `properties.icon` with a **literal filter**, so unlike `icon-image` there is no `match` expression resolving aliases for them. The filters still listed only the legacy German names:

```ts
["in", `${propPrefix}icon`, "EingesperrteAbgeschnittene", "Obdachlose"],
```

Once features began storing aliases (`babsEingesperrte`), every newly placed casualty icon fell through to the generic label — wrong position, and wrong colour for the centred pair. Only pre-migration features still rendered correctly, which is why it survived review.

## The fix

Filters are now built from `iconIdentifiers()`, which expands a set of catalogue ids to every identifier that can denote them — alias, bare id, and any legacy name mapping to it. That is the same source of truth the `icon-image` match expression uses, so the two cannot drift.

```ts
const CASUALTIES_CENTRED = iconIdentifiers(["1304", "1303"]);
```

## Scope

Checked rather than assumed. The bug class is "literal comparison against a property the migration changed", and `icon` is the only such property:

| property | comparison sites | affected |
|---|---|---|
| `icon` | 3 | **yes — all fixed here** |
| `zoneType` | 5 | no, repo-owned values |
| `lineType` | 6 | no, repo-owned values |

Every other reference to `icon` in the style is `["has", …]`, which is value-agnostic. `iconRotation` is untouched. `iconType` is read nowhere. A sweep of every key in `LEGACY_ICON_IDS` across the source tree found no other stale references — the remaining hits are `zoneType`/`lineType` values that happen to share a name with a legacy icon.

## Testing

149 tests, `tsc` at 111, lint clean, build verified.

`casualtyLabels.test.ts` drives real features through the generated filters — all three identifier forms (legacy name, alias, bare id) in both style modes — and asserts **exactly one** layer claims each feature, since two would label it twice in different positions.

**Verified by mutation.** With the old filters restored, the legacy-name cases pass while every alias and id case fails — precisely the production symptom, which confirms the test would have caught this.

## Note for review

Adjacent, not a bug: `styleGenerator.ts:179,192` hardcode their `zoneType` lists where the neighbouring filters derive theirs from `ZoneTypes`. The values are correct today and `lineAndZoneTypes.test.ts` catches a zone no layer draws, but it is the same maintenance shape. Left alone to keep this PR to the one fix.
