### PR TITLE
fix(ci): upload coverage only where it can actually attach

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,14 @@
 name: Automated Tests and Linting
+
+# Tests and linting only — deliberately no coverage upload.
+#
+# upload-code-coverage can only attach a report to a pull request or the default branch.
+# This workflow runs on push to every branch except main/develop, so before a PR exists
+# there is nothing to attach to and the upload fails with
+#   HTTP 400: Only default branch is allowed if no pull_request_number is provided
+# (which is why re-running after opening the PR used to fix it). Once a PR does exist,
+# main.yml runs on the pull_request event — which fires on every push to the head branch —
+# and uploads both reports with a proper PR number, so uploading here only duplicated it.
 permissions: read-all
 on:
   push:
@@ -11,24 +21,6 @@ jobs:
     uses: ./.github/workflows/ui-workflow.yml
     with:
       build: false
-  upload-coverage-typescript:
-    needs: ui-tests
-    if: ${{ !cancelled() && needs.ui-tests.result == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      code-quality: write
-    steps:
-      - name: Download coverage artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-report-typescript
-      - uses: actions/upload-code-coverage@d8e329117199404bba6fc81efe8093dc7c015e34 # v1.4.2
-        with:
-          file: cobertura-coverage.xml
-          language: TypeScript
-          label: code-coverage-agent
-
   go-tests:
     runs-on: ubuntu-latest
     name: "Go Tests"
@@ -61,21 +53,3 @@ jobs:
         with:
           name: coverage-report-go
           path: go-cobertura.xml
-
-  upload-coverage-go:
-    needs: go-tests
-    if: ${{ !cancelled() && needs.go-tests.result == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      code-quality: write
-    steps:
-      - name: Download Go coverage artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: coverage-report-go
-      - uses: actions/upload-code-coverage@d8e329117199404bba6fc81efe8093dc7c015e34 # v1.4.2
-        with:
-          file: go-cobertura.xml
-          language: Go
-          label: code-coverage-agent

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,17 @@ jobs:
 
   upload-coverage-typescript:
     needs: ui-build
-    if: ${{ !cancelled() && needs.ui-build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Coverage attaches to a pull request or the default branch. This workflow also
+    # runs on v* tag pushes, which are neither — upload-code-coverage rejects those
+    # with "Only default branch is allowed if no pull_request_number is provided", so
+    # skip them rather than fail the release run.
+    if: >-
+      ${{ !cancelled()
+      && needs.ui-build.result == 'success'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
+      && (github.event_name == 'pull_request'
+          || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -91,7 +101,17 @@ jobs:
 
   upload-coverage-go:
     needs: docker-build
-    if: ${{ !cancelled() && needs.docker-build.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Coverage attaches to a pull request or the default branch. This workflow also
+    # runs on v* tag pushes, which are neither — upload-code-coverage rejects those
+    # with "Only default branch is allowed if no pull_request_number is provided", so
+    # skip them rather than fail the release run.
+    if: >-
+      ${{ !cancelled()
+      && needs.docker-build.result == 'success'
+      && (github.event_name != 'pull_request'
+          || github.event.pull_request.head.repo.full_name == github.repository)
+      && (github.event_name == 'pull_request'
+          || github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fixes the intermittent CI failure:

```
Error: Coverage upload failed (HTTP 400): Only default branch is allowed
if no pull_request_number is provided.
```

Net effect is a **deletion** — 38 lines removed, 32 added.

## Why it happens

`upload-code-coverage` can only attach a report to a **pull request** or the **default branch**. Given neither, it fails the run.

**`build.yaml` could never satisfy that.** It runs on push to every branch except main/develop, so there is no `pull_request` event to carry a PR number. Per the action's README it falls back to `gh pr list` for push events, which finds nothing until the PR is opened — which is exactly why re-running after opening one used to fix it, and why this read as flakiness.

**`main.yml` also triggers on `v*` tag pushes.** A tag is neither a PR nor the default branch, so the same 400 would have failed **every release run** — latent rather than intermittent, and it would have surfaced at the worst moment.

## Why deletion rather than a guard

The first version of this added a `gh pr list` gate to `build.yaml`, mirroring what the action does internally. Checking whether that was necessary showed it wasn't:

- Both coverage artifacts are produced independently on the `main.yml` path — TypeScript from `ui-workflow.yml`, Go from `docker-workflow.yml`.
- `main.yml`'s `ui-build` is not event-gated, so it runs on `pull_request` too.
- `pull_request` fires on `synchronize`, i.e. **every push to the head branch**.

So once a PR exists, `main.yml` already uploads both reports with a proper PR number — meaning `build.yaml`'s uploads were **impossible before a PR and duplicates after it**. They are removed instead of guarded, which fixes the failure by deleting the thing that could not work.

Deliberately not `fail-on-error: false`, which the error message itself suggests: that would also swallow genuine upload failures, turning a real regression into a green run.

## Result

Coverage now uploads from exactly one place, for the two cases where it can work:

| trigger | uploads? | note |
|---|---|---|
| same-repo PR → develop | **yes** | unchanged |
| push to develop (default) | **yes** | unchanged |
| fork PR | skip | unchanged — no write access to the base repo |
| push to main | skip | would have 400'd — main is not the default branch |
| push to `v*` tag | skip | would have 400'd — the release-time fix |
| push to a feature branch | skip | was the reported failure; `main.yml` covers it once a PR exists |

`build.yaml` still runs the tests and still publishes `go-cobertura.xml` as an artifact, so nothing about test execution or reporting changes.

## Tradeoff

The one behaviour lost: a PR that does **not** target main or develop gets no coverage, because `main.yml` does not run for it. Relevant only for stacked PRs onto a feature branch. Say the word and the `gh pr list` gate can come back for that case, at the cost of the extra step and the duplicate uploads.

## Verified

Both workflows parse, no `uses: actions/upload-code-coverage` remains outside `main.yml`, and the guard was checked by truth table across every way these workflows can trigger — including that its parentheses balance and its `format('refs/heads/{0}', …)` placeholder is not double-escaped. A mangled expression there silently evaluates false, which would have quietly disabled coverage everywhere rather than erroring.

## Note

`pull_request_number` is **not** an input to this action, despite the error message naming it — it is derived internally, so it cannot be passed in. Worth knowing, since it is the obvious first thing to reach for. Arguably the action should skip gracefully here as it already does for fork PRs and merge-queue runs, rather than failing; that would be an upstream report.
