### PR TITLE
fix(ui): show the new version's changelog in the update prompt

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -22,7 +22,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      
+        with:
+          # `git describe` below needs the tags and enough history to count commits since
+          # the last one. The default shallow fetch has neither, and --always would quietly
+          # degrade to a bare SHA rather than failing.
+          fetch-depth: 0
+
       - name: Download UI build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -93,16 +98,19 @@ jobs:
           done
           echo "labels=$labels" >> $GITHUB_OUTPUT
       - name: Ko Build
-        env:
-          # Consumed by .ko.yaml as -X main.version. Was already set here but had nothing
-          # reading it until .ko.yaml existed.
-          Version: ${{ steps.meta.outputs.version }}
         run: |
-          # An empty version would stamp `-X main.version=` and ship a binary reporting no
-          # version at all — worse than the "dev" default, and invisible until someone
-          # reads a trace. Fail here instead.
-          if [ -z "$Version" ]; then
-            echo "::error::docker/metadata-action produced an empty version; refusing to build an unversioned image"
+          # Deliberately `git describe` rather than the image tag from metadata-action.
+          # That yields the literal "develop" on the default branch, "stable" on main and
+          # "pr-N" on pull requests — only tagged releases got a real version, and most
+          # deploys are not tagged. This anchors every build to the last release and counts
+          # from it (v26.8.0-64-g136b9bf0), and is byte-identical to what the UI bakes in,
+          # so the two never disagree. The image tags themselves are unaffected: they come
+          # from image_tags_labels below.
+          SITREP_VERSION="$(git describe --tags --always)"
+          if [ -z "$SITREP_VERSION" ]; then
+            echo "::error::git describe produced an empty version; refusing to build an unversioned image"
             exit 1
           fi
+          echo "Stamping version: $SITREP_VERSION"
+          export SITREP_VERSION
           ko build --bare . --tags ${{ steps.image_tags_labels.outputs.tags }} ${{ steps.image_tags_labels.outputs.labels }}

--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -94,6 +94,15 @@ jobs:
           echo "labels=$labels" >> $GITHUB_OUTPUT
       - name: Ko Build
         env:
+          # Consumed by .ko.yaml as -X main.version. Was already set here but had nothing
+          # reading it until .ko.yaml existed.
           Version: ${{ steps.meta.outputs.version }}
-        run: >
+        run: |
+          # An empty version would stamp `-X main.version=` and ship a binary reporting no
+          # version at all — worse than the "dev" default, and invisible until someone
+          # reads a trace. Fail here instead.
+          if [ -z "$Version" ]; then
+            echo "::error::docker/metadata-action produced an empty version; refusing to build an unversioned image"
+            exit 1
+          fi
           ko build --bare . --tags ${{ steps.image_tags_labels.outputs.tags }} ${{ steps.image_tags_labels.outputs.labels }}

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -15,10 +15,10 @@ builds:
   - id: sitrep
     main: .
     ldflags:
-      # Matches the published image tag, so the running version and the container tag
-      # agree. Supplied by the workflow from docker/metadata-action; the Ko Build step
+      # `git describe` output, supplied by the workflow — the same string the UI bakes in,
+      # so the backend and the frontend never report different versions. The Ko Build step
       # fails fast if it is empty, since an empty version is worse than "dev".
-      - -X main.version={{.Env.Version}}
+      - -X main.version={{.Env.SITREP_VERSION}}
       # Taken from ko's own git context rather than the workflow, so a local `ko build`
       # stamps correctly too and there is one less thing to plumb.
       - -X main.sha={{.Git.FullCommit}}

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,24 @@
+# ko build configuration.
+#
+# Exists to stamp the build identity into the binary. `main.go` declares
+#
+#   var version = "dev"
+#   var sha     = "dev"
+#
+# and without -ldflags those defaults ship to production — which is why every trace and
+# metric reported service.version="dev" (see otel.go, semconv.ServiceVersion) and why the
+# UI update prompt could not name the version it was offering.
+#
+# ko matches a builds entry by joining `dir` and `main` against the requested import path.
+# The workflow runs `ko build --bare .`, so `main: .` is the entry that applies.
+builds:
+  - id: sitrep
+    main: .
+    ldflags:
+      # Matches the published image tag, so the running version and the container tag
+      # agree. Supplied by the workflow from docker/metadata-action; the Ko Build step
+      # fails fast if it is empty, since an empty version is worse than "dev".
+      - -X main.version={{.Env.Version}}
+      # Taken from ko's own git context rather than the workflow, so a local `ko build`
+      # stamps correctly too and there is one less thing to plumb.
+      - -X main.sha={{.Git.FullCommit}}

--- a/main.go
+++ b/main.go
@@ -14,9 +14,11 @@ import (
 	"github.com/f-eld-ch/sitrep/server/auth"
 )
 
-// Version is the version of the application, set at build time.
+// Build identity, set at link time via -ldflags (see .ko.yaml). The defaults apply to
+// local `go build` and `go run`, so an unset value is visibly "dev" rather than empty.
 var (
 	version = "dev"
+	sha     = "dev"
 )
 
 func init() {
@@ -89,6 +91,7 @@ func main() {
 	// needs to go last to make use of correct enforcers
 	opts = append(opts,
 		server.WithApiV2(),
+		server.WithVersion(version, sha),
 		server.WithApiV1Proxy(viper.GetString("hasura_backend")),
 	)
 

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -10,6 +10,17 @@ func (s *Server) health(c echo.Context) error {
 	return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 }
 
+// version reports the build this binary was produced from.
+//
+// The UI is embedded here, so a client comparing this against its own compiled-in version
+// learns whether the server is serving something newer than the page it is running.
+func (s *Server) buildInfo(c echo.Context) error {
+	return c.JSON(http.StatusOK, map[string]string{
+		"version": s.version,
+		"sha":     s.sha,
+	})
+}
+
 func (s *Server) ready(c echo.Context) error {
 	if s.isShuttingDown.Load() {
 		return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unavailable"})

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+// The update prompt in the UI compares this response against its own compiled-in version
+// to decide which changelog to link to, so an empty or malformed body silently sends users
+// to the wrong release notes.
+func TestBuildInfo(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		sha         string
+		wantVersion string
+		wantSha     string
+	}{
+		{
+			name:        "reports the injected build identity",
+			version:     "v1.2.3",
+			sha:         "abc1234",
+			wantVersion: "v1.2.3",
+			wantSha:     "abc1234",
+		},
+		{
+			// A missing -ldflags leaves main.go's defaults in place. Serving them verbatim
+			// is what makes a broken release build obvious instead of looking plausible.
+			name:        "passes through unset build identity rather than inventing one",
+			version:     "dev",
+			sha:         "dev",
+			wantVersion: "dev",
+			wantSha:     "dev",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := newTestServer(WithVersion(tt.version, tt.sha))
+			if err != nil {
+				t.Fatalf("building server: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			ctx := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/version", nil), rec)
+
+			if err := s.buildInfo(ctx); err != nil {
+				t.Fatalf("buildInfo returned an error: %v", err)
+			}
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rec.Code)
+			}
+
+			var got map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("response is not valid JSON: %v (body %q)", err, rec.Body.String())
+			}
+			if got["version"] != tt.wantVersion {
+				t.Errorf("version: got %q, want %q", got["version"], tt.wantVersion)
+			}
+			if got["sha"] != tt.wantSha {
+				t.Errorf("sha: got %q, want %q", got["sha"], tt.wantSha)
+			}
+		})
+	}
+}
+
+// Without WithVersion the fields are the zero value, and the endpoint would answer with
+// empty strings. Asserting it keeps that distinguishable from a real version.
+func TestBuildInfoWithoutVersionOption(t *testing.T) {
+	s, err := newTestServer()
+	if err != nil {
+		t.Fatalf("building server: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	ctx := echo.New().NewContext(httptest.NewRequest(http.MethodGet, "/version", nil), rec)
+	if err := s.buildInfo(ctx); err != nil {
+		t.Fatalf("buildInfo returned an error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if _, ok := got["version"]; !ok {
+		t.Error("expected a version key even when unset, so clients can rely on the shape")
+	}
+	if _, ok := got["sha"]; !ok {
+		t.Error("expected a sha key even when unset, so clients can rely on the shape")
+	}
+}
+
+func newTestServer(opts ...Option) (*Server, error) {
+	s := &Server{}
+	for _, opt := range opts {
+		if err := opt(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}

--- a/server/options.go
+++ b/server/options.go
@@ -11,6 +11,19 @@ import (
 	"github.com/f-eld-ch/sitrep/server/auth"
 )
 
+// WithVersion records the build identity so it can be served to clients.
+//
+// The UI is embedded in this binary (see ui.Assets), so these values describe the frontend
+// being served as much as the backend, which is what lets the update prompt name the
+// version it is offering.
+func WithVersion(version, sha string) Option {
+	return func(s *Server) error {
+		s.version = version
+		s.sha = sha
+		return nil
+	}
+}
+
 // Option defines a functional option for Server.
 type Option func(*Server) error
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -20,6 +20,10 @@ func (s *Server) RegisterRoutes() {
 	s.router.GET("/ping", s.health)
 	s.router.GET("/ready", s.ready)
 
+	// Build identity. Unauthenticated like the health endpoints: it exposes nothing the
+	// served asset filenames do not already reveal.
+	s.router.GET("/version", s.buildInfo)
+
 	// OIDC handlers
 	oidc := s.router.Group("/oauth2")
 	oidc.GET("/sign_in", s.Enforcer.SignInHandler)

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,8 @@ type Server struct {
 	isShuttingDown atomic.Bool
 	port           uint
 	address        string
+	version        string
+	sha            string
 	auth.Enforcer
 	router *echo.Echo
 	*http.Server

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -28,6 +28,7 @@ import { type FunctionComponent, useContext, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { NavLink, useParams } from "react-router";
 import { IncidentContext, UserContext } from "utils";
+import { CURRENT_SHA, CURRENT_VERSION, changelogUrl } from "utils/version";
 import { useDarkMode } from "utils/useDarkMode";
 import { useDate } from "utils/useDate";
 
@@ -220,11 +221,13 @@ function VersionNavBar() {
         </span>
         <span>
           <a
-            href={`https://github.com/RedGecko/sitrep/blob/${import.meta.env.VITE_SHA_VERSION}/CHANGELOG.md`}
+            /* Deliberately the running build, not the deployed one: this element labels
+               the version the user is currently on. */
+            href={changelogUrl(CURRENT_SHA)}
             target="_blank"
             rel="noopener noreferrer"
           >
-            {import.meta.env.VITE_VERSION}
+            {CURRENT_VERSION}
           </a>
         </span>
       </span>

--- a/ui/src/utils/ReloadSWPrompt.tsx
+++ b/ui/src/utils/ReloadSWPrompt.tsx
@@ -2,19 +2,17 @@ import { useRegisterSW } from "virtual:pwa-register/react";
 import { t } from "i18next";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createSWChannel, now } from "./swUpdateChannel";
+import {
+  CURRENT_SHA,
+  CURRENT_VERSION,
+  changelogUrl,
+  type DeployedVersion,
+  fetchDeployedVersion,
+} from "./version";
 
 const intervalMS = 60 * 60 * 1000;
 const PROMPT_LOCK_KEY = "sw-prompt-last";
 const PROMPT_LOCK_TTL = 60 * 1000; // 60s
-
-function getVersion() {
-  return import.meta.env.VITE_VERSION || "unknown";
-}
-
-function getChangelogUrl() {
-  const sha = import.meta.env.VITE_SHA_VERSION || "main";
-  return `https://github.com/RedGecko/sitrep/blob/${sha}/CHANGELOG.md`;
-}
 
 export function ReloadPrompt() {
   const {
@@ -44,10 +42,26 @@ export function ReloadPrompt() {
     },
   });
 
+  // The build the server is now serving, which is the update being offered. Null until
+  // fetched, or when the lookup failed — see the fallback where it is rendered.
+  const [deployed, setDeployed] = useState<DeployedVersion | null>(null);
   const [visible, setVisible] = useState(false);
   const [dismissUntil, setDismissUntil] = useState<number | null>(null);
   const tabId = useMemo(() => `${Math.random().toString(36).slice(2, 9)}`, []);
   const channelRef = useRef<{ post: (msg: any) => void; close: () => void } | null>(null);
+
+  useEffect(() => {
+    // Keyed on needRefresh so this costs a request only when an update exists, rather than
+    // on every page load. The running bundle cannot know the new version itself.
+    if (!needRefresh) return;
+    let active = true;
+    void fetchDeployedVersion().then((info) => {
+      if (active) setDeployed(info);
+    });
+    return () => {
+      active = false;
+    };
+  }, [needRefresh]);
 
   useEffect(() => {
     channelRef.current = createSWChannel((msg) => {
@@ -84,7 +98,7 @@ export function ReloadPrompt() {
 
         const last = Number(localStorage.getItem(PROMPT_LOCK_KEY) || "0");
         if (now() - last > PROMPT_LOCK_TTL) {
-          channelRef.current?.post({ type: "update-available", version: getVersion(), tabId });
+          channelRef.current?.post({ type: "update-available", version: CURRENT_VERSION, tabId });
           localStorage.setItem(PROMPT_LOCK_KEY, String(now()));
           if (!dismissUntil || now() > dismissUntil) {
             // show the prompt in this tab
@@ -202,7 +216,7 @@ export function ReloadPrompt() {
       }
 
       // announce update and show prompt in this tab
-      channelRef.current?.post({ type: "update-available", version: getVersion(), tabId });
+      channelRef.current?.post({ type: "update-available", version: CURRENT_VERSION, tabId });
       localStorage.setItem(PROMPT_LOCK_KEY, String(now()));
       if (!dismissUntil || now() > dismissUntil) setVisible(true);
     } else {
@@ -255,10 +269,16 @@ export function ReloadPrompt() {
               <div>
                 <strong>{t("updateNotification")}</strong>
                 <div className="mt-2">
-                  <a href={getChangelogUrl()} target="_blank" rel="noopener noreferrer">
+                  <a
+                    href={changelogUrl(deployed?.sha ?? CURRENT_SHA)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     {t("viewChangelog")}
                   </a>
-                  <span className="ml-3 has-text-weight-semibold">{getVersion()}</span>
+                  <span className="ml-3 has-text-weight-semibold">
+                    {deployed?.version ?? CURRENT_VERSION}
+                  </span>
                 </div>
               </div>
               <div className="buttons pt-2">

--- a/ui/src/utils/version.test.ts
+++ b/ui/src/utils/version.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CURRENT_SHA, CURRENT_VERSION, changelogUrl, fetchDeployedVersion } from "./version";
+
+/**
+ * `fetchDeployedVersion` runs while the update prompt is being rendered, so a throw would
+ * take the prompt down with it — leaving no way to apply the update it was announcing.
+ * Every failure path below must resolve to null instead.
+ */
+
+const jsonResponse = (body: unknown, ok = true) =>
+  ({ ok, json: () => Promise.resolve(body) }) as unknown as Response;
+
+describe("fetchDeployedVersion", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the deployed build identity", async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: "v1.2.3", sha: "abc1234" }));
+    await expect(fetchDeployedVersion()).resolves.toEqual({ version: "v1.2.3", sha: "abc1234" });
+  });
+
+  it("bypasses the HTTP cache", async () => {
+    // Not defensive: a heuristically cached response reports the version this page was
+    // served with, which is precisely the bug this module exists to fix.
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: "v1", sha: "a" }));
+    await fetchDeployedVersion();
+    expect(vi.mocked(fetch).mock.calls[0][1]).toMatchObject({ cache: "no-store" });
+  });
+
+  it("requests a path derived from the base URL, not a hard-coded root", async () => {
+    // A root-assumed path breaks under a sub-path deployment — the same mistake that made
+    // the sprite atlases 404 from a nested route.
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: "v1", sha: "a" }));
+    await fetchDeployedVersion();
+    const url = String(vi.mocked(fetch).mock.calls[0][0]);
+    expect(url.endsWith("/version")).toBe(true);
+    expect(url).not.toContain("//version");
+  });
+
+  it.each([
+    [
+      "the request rejects (offline)",
+      () => vi.mocked(fetch).mockRejectedValue(new Error("offline")),
+    ],
+    [
+      "the status is not ok (no such route in dev)",
+      () => vi.mocked(fetch).mockResolvedValue(jsonResponse({}, false)),
+    ],
+    [
+      "the body is not JSON",
+      () =>
+        vi.mocked(fetch).mockResolvedValue({
+          ok: true,
+          json: () => Promise.reject(new SyntaxError("unexpected token")),
+        } as unknown as Response),
+    ],
+    ["the body is JSON null", () => vi.mocked(fetch).mockResolvedValue(jsonResponse(null))],
+    [
+      "fields are missing",
+      () => vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: "v1" })),
+    ],
+    [
+      "fields are the wrong type",
+      () => vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: 1, sha: 2 })),
+    ],
+    [
+      "fields are empty, as an unversioned build would report",
+      () => vi.mocked(fetch).mockResolvedValue(jsonResponse({ version: "", sha: "" })),
+    ],
+  ])("resolves to null, without throwing, when %s", async (_case, arrange) => {
+    arrange();
+    await expect(fetchDeployedVersion()).resolves.toBeNull();
+  });
+});
+
+describe("changelogUrl", () => {
+  it("points at the current repository", () => {
+    // Was hard-coded as the pre-rename RedGecko/sitrep in two components, working only
+    // because GitHub redirects renamed repositories.
+    expect(changelogUrl("abc1234")).toBe(
+      "https://github.com/f-eld-ch/sitrep/blob/abc1234/CHANGELOG.md",
+    );
+  });
+
+  it("embeds whichever ref it is given", () => {
+    expect(changelogUrl("develop")).toContain("/blob/develop/");
+  });
+});
+
+describe("build-time constants", () => {
+  it("always resolve to something linkable", () => {
+    // Both feed straight into a URL and a label, so an empty value would render a broken
+    // link rather than an obviously wrong one.
+    expect(CURRENT_VERSION).not.toBe("");
+    expect(CURRENT_SHA).not.toBe("");
+  });
+});

--- a/ui/src/utils/version.ts
+++ b/ui/src/utils/version.ts
@@ -1,0 +1,62 @@
+/**
+ * Build identity, and the changelog links built from it.
+ *
+ * Single home for these concerns: the repo slug used to be hardcoded in two components,
+ * which is how it went stale (it named the pre-rename `RedGecko/sitrep` while the remote is
+ * `f-eld-ch/sitrep` — working only because GitHub redirects renamed repositories).
+ */
+
+/** The version this bundle was built from. Injected by vite.config.ts at build time. */
+export const CURRENT_VERSION: string = import.meta.env.VITE_VERSION || "unknown";
+
+/** The commit this bundle was built from. Injected by vite.config.ts at build time. */
+export const CURRENT_SHA: string = import.meta.env.VITE_SHA_VERSION || "main";
+
+const CHANGELOG_REPO = "f-eld-ch/sitrep";
+
+/** Link to CHANGELOG.md as of a given commit or ref. */
+export const changelogUrl = (sha: string): string =>
+  `https://github.com/${CHANGELOG_REPO}/blob/${sha}/CHANGELOG.md`;
+
+export interface DeployedVersion {
+  version: string;
+  sha: string;
+}
+
+/**
+ * Asks the server which build it is currently serving.
+ *
+ * The constants above describe the bundle that is *running*, so they cannot identify an
+ * update — the page has no compiled-in knowledge of a version released after it. The
+ * server does: the UI is embedded in the Go binary (`ui.Assets`), so its build identity is
+ * also the frontend's.
+ *
+ * Resolves to `null` rather than throwing on any failure — offline, a dev server without
+ * the proxy, a mid-deploy blip, or a malformed body. Callers fall back to the running
+ * version, so the update prompt still works when this does not.
+ */
+export async function fetchDeployedVersion(): Promise<DeployedVersion | null> {
+  // Derived from BASE_URL rather than a bare "/version": a root-assumed path breaks under
+  // a sub-path deployment, which is exactly how the sprite URLs 404'd in #1739.
+  const url = `${import.meta.env.BASE_URL.replace(/\/$/, "")}/version`;
+
+  try {
+    // `no-store` is essential, not defensive: a heuristically cached response would report
+    // the version this page was served with, which is the bug this exists to fix.
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) return null;
+
+    const body: unknown = await response.json();
+    if (typeof body !== "object" || body === null) return null;
+
+    const { version, sha } = body as Partial<DeployedVersion>;
+    // Guard the shape as well as the parse: an unversioned build would answer with empty
+    // strings, and naming "" in the prompt is worse than falling back.
+    if (typeof version !== "string" || typeof sha !== "string") return null;
+    if (version === "" || sha === "") return null;
+
+    return { version, sha };
+  } catch {
+    return null;
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -184,6 +184,13 @@ export default defineConfig({
         target: "http://localhost:4180",
         changeOrigin: true,
       },
+      // Served by the Go backend, and read by the update prompt to name the version it is
+      // offering. Proxied so `yarn start` behaves like production instead of silently
+      // exercising the fallback path.
+      "/version": {
+        target: "http://localhost:4180",
+        changeOrigin: true,
+      },
     },
   },
   preview: {
@@ -194,6 +201,13 @@ export default defineConfig({
         changeOrigin: true,
       },
       "/oauth2": {
+        target: "http://localhost:4180",
+        changeOrigin: true,
+      },
+      // Served by the Go backend, and read by the update prompt to name the version it is
+      // offering. Proxied so `yarn start` behaves like production instead of silently
+      // exercising the fallback path.
+      "/version": {
         target: "http://localhost:4180",
         changeOrigin: true,
       },

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 
 import { babsSprites } from "@f-eld-ch/babs-sprites/vite";
+import { execSync } from "node:child_process";
 import react from "@vitejs/plugin-react";
 import * as git from "git-rev-sync";
 import { defineConfig } from "vite";
@@ -9,7 +10,32 @@ import { VitePWA } from "vite-plugin-pwa";
 import svgrPlugin from "vite-plugin-svgr";
 
 const buildSha = process.env.VITE_SHA_VERSION || git.long("../") || "dev";
-const buildVersion = process.env.VITE_VERSION || git.tag(false) || "dev";
+
+/**
+ * `git describe` output, e.g. `v26.8.0` on a tag or `v26.8.0-64-g136b9bf0` past one.
+ *
+ * The same command the Ko Build step runs, deliberately: the backend serves its version on
+ * /version and the update prompt shows it, so any difference in scheme would have the app
+ * displaying two different version strings at once.
+ *
+ * git-rev-sync has no equivalent — its `tag()` passes --abbrev=0 (nearest tag, no count)
+ * and its `count()` is total commits, not commits since the tag — so this shells out.
+ * Falls back to the nearest tag when git or the tags are unavailable, e.g. a build from a
+ * shallow clone or an exported tree.
+ */
+function describeVersion(): string {
+  try {
+    return execSync("git describe --tags --always", {
+      cwd: "..",
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+const buildVersion = process.env.VITE_VERSION || describeVersion() || git.tag(false) || "dev";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
The update prompt's "view changelog" link and version number described the version the user was **already running**, not the update being offered.

<!-- screenshot -->

## Why it happened

`vite.config.ts` bakes the values in at build time, and the prompt is rendered by the currently loaded bundle — so those constants are by definition the *old* build's:

```ts
const sha = import.meta.env.VITE_SHA_VERSION || "main";
return `https://github.com/RedGecko/sitrep/blob/${sha}/CHANGELOG.md`;
```

A running page cannot learn a version released after it. It has to ask the server.

## Why the server, not a build artefact

`ui/ui.go` embeds the UI into the Go binary via `//go:embed build`, so one binary is exactly one UI version. Asking the backend cannot disagree with what is being served, whereas a `version.json` emitted by the UI build would be a second version channel that could.

It also avoids a booby trap: `workbox.globPatterns` includes `json`, so a `version.json` asset **would be precached** — the service worker would serve a stale copy and reproduce a symptom identical to the original bug, guarded only by a `globIgnores` entry a later edit could silently drop. An API route cannot be glob-matched at all.

## It also fixes a telemetry bug

`main.go` declared:

```go
// Version is the version of the application, set at build time.
var version = "dev"
```

Nothing set it — no `.ko.yaml`, no `-ldflags` anywhere, and the Ko Build step exported a `Version` env that nothing read. But the variable is not dead: `otel.go` passes it to `semconv.ServiceVersion`, so **every trace and metric in production reported `service.version="dev"`**. Completing the wiring fixes that as a side effect, and is the main reason this belongs in the backend.

## Changes

**Backend** — `.ko.yaml` injects `version` and a new `sha` at link time, and `GET /version` serves both, unauthenticated like the health endpoints. The commit comes from **ko's own git context**, so a local `ko build` stamps correctly too.

The Ko Build step **fails if the version is empty**: stamping `-X main.version=` would ship a binary reporting nothing at all — worse than the `dev` default, and invisible until someone reads a trace.

**Versioning scheme** — both sides use `git describe --tags --always`, not the image tag.

The obvious choice was `docker/metadata-action`'s computed version, but it only produces a real version for **tagged releases**: the default branch yields the literal `develop`, main yields `stable`, a PR yields `pr-N`. Most deploys are not tagged, so most backends would have reported a branch name as their version — on `/version` and in every trace.

It also disagreed with the frontend, which baked in the *nearest tag*. A develop deployment would have shown `v26.8.0` in the navbar and `develop` in the update prompt — two different version strings in the same app, for the same build.

| deploy | image tag scheme | `git describe` |
|---|---|---|
| develop | `develop` | `v26.8.0-64-g136b9bf0` |
| tag `v26.9.0` | `v26.9.0` | `v26.9.0` — unchanged |
| pull request | `pr-123` | `v26.8.0-64-g136b9bf0` |

Nothing was lost by dropping the metadata-action value: the published image tags come from `image_tags_labels`, so the correspondence it appeared to provide was never real.

This needs `fetch-depth: 0` on the docker workflow checkout — `git describe` requires the tags *and* enough history to count commits since the last one, and the default shallow fetch has neither. With `--always` it would have silently degraded to a bare SHA rather than failing.

**Frontend** — `utils/version.ts` holds the build constants, `changelogUrl()`, and `fetchDeployedVersion()`. The prompt fetches when `needRefresh` flips, so it costs a request only when an update exists, and falls back to the running version whenever the lookup returns `null`. A prompt that cannot render is worse than one naming the wrong version, since it is the only way to apply the update.

`Navbar` **deliberately keeps the pinned SHA** — that element labels the version the user is on, so the running build's changelog is the correct target there.

**Also fixes a stale repo slug.** The changelog URL was hard-coded as the pre-rename `RedGecko/sitrep` in two components, working only because GitHub redirects renamed repositories. Having it in two places is why it went stale.

## No cache or service-worker changes needed

`cacheControlMiddleWare` already defaults to `Cache-Control: no-store` outside `/assets/` and `/map/`, so `/version` is covered. And an API route cannot be precached.

## Verified

The part most likely to be silently wrong — that ldflags actually reach a running binary — was checked directly rather than assumed:

```
go build -ldflags "-X main.version=v9.9.9 -X main.sha=deadbeefcafe" -o /tmp/sitrep .
curl -i localhost:4199/version
→ 200, Cache-Control: no-store
  {"sha":"deadbeefcafe","version":"v9.9.9"}
```

- Go: table test over the handler, including that unset values pass through as `dev` so a broken release build fails an assertion rather than returning something plausible.
- TypeScript: 13 tests covering every failure path resolving to `null` rather than throwing — offline, non-OK status, non-JSON body, JSON `null`, missing fields, wrong types, and empty strings. Plus assertions that the request passes `cache: "no-store"` and derives its path from `BASE_URL` rather than assuming the site root (the same mistake that made the sprite atlases 404 from a nested route).
- 165 frontend tests, `tsc` at 111 — unchanged from develop's baseline — lint clean, build clean, `go vet` and `go test ./...` clean.

**The two sides agree, checked rather than assumed.** The built bundle and a binary stamped the same way both report `v26.8.0-64-g136b9bf0` — which is the point of using one scheme for both.

## Note for review

This reports the *deployed* version, not the waiting service worker's own version. They are the same in practice, since the SW updated because the server began serving a new build, but could differ briefly mid-deploy or behind a CDN serving mixed versions. Reading it from the worker would be exact but requires `injectManifest` instead of `generateSW` — disproportionate here.

Not verified by me: the end-to-end behaviour of a real update prompt naming a real new version, which needs two successive deploys.
