### PR TITLE
fix(ci): improve builds by gitignoring go-coverage.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,15 @@ coverage
 
 # Go coverage profiles
 coverage.out
+# The name the workflows actually pass to -coverprofile; the entry above never matched it.
+# Left untracked it makes the working tree dirty, which breaks any build step that inspects
+# git state — ko refuses to build a dirty tree rather than stamp a commit that does not
+# describe what was built.
+go-coverage.out
 go-cobertura.xml
 
 # Vitest coverage reports
 ui/coverage/
+
+# TypeScript incremental build state, emitted for composite projects (tsconfig.node.json)
+*.tsbuildinfo


### PR DESCRIPTION
One-line `.gitignore` fix for a name mismatch that has been there as long as the entry.

## The mismatch

`.gitignore` lists `coverage.out`, but both workflows pass a different filename:

```yaml
run: go test -coverprofile=go-coverage.out ./...
```

So the coverage profile is left **untracked** on every run that produces it, in both `build.yaml` and `docker-workflow.yml`.

## Why it matters

Harmless while nothing looks at git state. But it makes the working tree dirty, and a build step that inspects git will refuse to proceed rather than stamp a commit that does not describe what was built. `ko` does exactly that once given a build config, failing with:

```
git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? go-coverage.out
```

Landing this separately so the fix is available independently of the change that surfaced it.

## Verified

Reproduced the docker job's file state in the order the steps run — `go test`, the cobertura conversion, and the downloaded `ui/build` artifact — then confirmed `git status --porcelain` is clean:

| file | status |
|---|---|
| `go-coverage.out` | ignored — **this PR** |
| `go-cobertura.xml` | already ignored by name |
| `ui/build/**` | already ignored by `ui/.gitignore` |

## Also

Ignores `*.tsbuildinfo`, which `tsc` emits for the composite `tsconfig.node.json` project. Not produced by CI today — `yarn build` is just `vite build` — but it is the same class of stray artifact, and any step that runs `tsc` before a git-inspecting build would hit the same failure.
