### PR TITLE
feat(ui): add a language switcher to the settings dropdown

### DIFF
--- a/ui/src/components/LanguageSwitcher.test.tsx
+++ b/ui/src/components/LanguageSwitcher.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import LanguageSwitcher, { LANGUAGES } from "./LanguageSwitcher";
+
+const mockChangeLanguage = vi.fn();
+let resolvedLanguage = "de";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: {
+      get resolvedLanguage() {
+        return resolvedLanguage;
+      },
+      get language() {
+        return resolvedLanguage;
+      },
+      changeLanguage: mockChangeLanguage,
+    },
+  }),
+}));
+
+beforeEach(() => {
+  mockChangeLanguage.mockClear();
+  resolvedLanguage = "de";
+});
+
+describe("LanguageSwitcher", () => {
+  it("offers German, French and Italian, and not English", () => {
+    // English is excluded on purpose: the BABS catalogue has no English labels, so an
+    // English UI would be half translated.
+    render(<LanguageSwitcher />);
+    expect(screen.getByRole("button", { name: "Deutsch" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Français" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Italiano" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+
+  it("switches to the chosen language", () => {
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole("button", { name: "Italiano" }));
+    expect(mockChangeLanguage).toHaveBeenCalledExactlyOnceWith("it");
+  });
+
+  it("marks the active language as pressed, and only that one", () => {
+    resolvedLanguage = "fr";
+    render(<LanguageSwitcher />);
+    expect(screen.getByRole("button", { name: "Français" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Deutsch" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: "Italiano" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("treats a regional variant as its base language", () => {
+    // i18next resolves de-CH to de, which is the common case for this audience — the
+    // button must still read as active or the control looks broken.
+    resolvedLanguage = "de";
+    render(<LanguageSwitcher />);
+    expect(screen.getByRole("button", { name: "Deutsch" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("does not re-switch when the active language is clicked", () => {
+    resolvedLanguage = "de";
+    render(<LanguageSwitcher />);
+    fireEvent.click(screen.getByRole("button", { name: "Deutsch" }));
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+
+  it("shows no active language when the UI is in one it does not offer", () => {
+    // An English browser resolves to "en". Highlighting nothing is honest — clicking any
+    // button moves to a supported language — whereas pretending German is active would
+    // contradict the text on screen.
+    resolvedLanguage = "en";
+    render(<LanguageSwitcher />);
+    for (const language of LANGUAGES) {
+      expect(screen.getByRole("button", { name: language.name })).toHaveAttribute(
+        "aria-pressed",
+        "false",
+      );
+    }
+  });
+
+  it("labels each button with its own language for assistive tech", () => {
+    render(<LanguageSwitcher />);
+    for (const language of LANGUAGES) {
+      const button = screen.getByRole("button", { name: language.name });
+      // The visible text is an abbreviation, so the accessible name carries the autonym,
+      // and lang= stops a screen reader reading "Français" with English phonetics.
+      expect(button).toHaveTextContent(language.short);
+      expect(button).toHaveAttribute("lang", language.code);
+    }
+  });
+});

--- a/ui/src/components/LanguageSwitcher.tsx
+++ b/ui/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,78 @@
+import { faGlobe } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import classNames from "classnames";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Languages offered in the UI.
+ *
+ * English is deliberately absent: the BABS symbol catalogue has no English labels
+ * (`resolveBabsLang` maps anything unknown onto German), so an English UI would be half
+ * translated. It stays available via the `?lang=en` querystring for anyone who wants it.
+ *
+ * Labelled with autonyms rather than translated names — a language picker that names
+ * languages in a language you may not read is not much use, and it is the convention.
+ */
+const LANGUAGES = [
+  { code: "de", short: "DE", name: "Deutsch" },
+  { code: "fr", short: "FR", name: "Français" },
+  { code: "it", short: "IT", name: "Italiano" },
+] as const;
+
+/**
+ * Compact language picker for the settings dropdown.
+ *
+ * A segmented control rather than a cycling toggle like the dark-mode switch: with three
+ * options, cycling makes reaching the third a guessing game, and the current language is
+ * worth showing rather than inferring from the surrounding text.
+ */
+function LanguageSwitcher() {
+  const { i18n } = useTranslation();
+
+  // resolvedLanguage collapses regional variants, so "de-CH" matches the "de" button.
+  const active = i18n.resolvedLanguage ?? i18n.language;
+
+  return (
+    <div className="navbar-item">
+      <span className="icon-text is-flex-wrap-nowrap">
+        <span className="icon">
+          <FontAwesomeIcon icon={faGlobe} />
+        </span>
+        {/* `mb-0` because Bulma's .buttons carries a bottom margin meant for standalone
+            groups, which misaligns it against the icon inside a navbar item. */}
+        <span className="buttons has-addons are-small mb-0">
+          {LANGUAGES.map((language) => {
+            const isActive = active === language.code;
+            return (
+              <button
+                key={language.code}
+                type="button"
+                className={classNames("button", "is-small", {
+                  "is-primary is-selected": isActive,
+                })}
+                // The autonym is the accessible name; the visible label is an abbreviation.
+                title={language.name}
+                aria-label={language.name}
+                // aria-pressed rather than aria-current: these are toggle buttons, not
+                // navigation. Screen readers then announce which language is in effect.
+                aria-pressed={isActive}
+                lang={language.code}
+                onClick={() => {
+                  if (isActive) return;
+                  // Persisted by i18next-browser-languagedetector, which caches to
+                  // session and local storage on change (see i18n/index.ts detection).
+                  void i18n.changeLanguage(language.code);
+                }}
+              >
+                {language.short}
+              </button>
+            );
+          })}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default LanguageSwitcher;
+export { LANGUAGES };

--- a/ui/src/components/Navbar.test.tsx
+++ b/ui/src/components/Navbar.test.tsx
@@ -7,10 +7,17 @@ import Navbar from "./Navbar";
 
 const mockDispatch = vi.fn();
 
-// Mock the useTranslation hook
+// Mock the useTranslation hook. LanguageSwitcher reads i18n off the same hook, so the
+// mock has to supply it or every render of the navbar throws.
+const mockChangeLanguage = vi.fn();
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
+    i18n: {
+      resolvedLanguage: "de",
+      language: "de",
+      changeLanguage: mockChangeLanguage,
+    },
   }),
 }));
 

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -30,6 +30,7 @@ import { NavLink, useParams } from "react-router";
 import { IncidentContext, UserContext } from "utils";
 import { CURRENT_SHA, CURRENT_VERSION, changelogUrl } from "utils/version";
 import { useDarkMode } from "utils/useDarkMode";
+import LanguageSwitcher from "./LanguageSwitcher";
 import { useDate } from "utils/useDate";
 
 const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false }) => {
@@ -257,6 +258,7 @@ function UserNavBar() {
           </span>
         </div>
         <DarkModeSwitcher />
+        <LanguageSwitcher />
         <hr className="navbar-divider" />
         <a className="navbar-item" href="/oauth2/sign_out">
           <span className="icon-text is-flex-wrap-nowrap is-capitalized">

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -1,3 +1,4 @@
 export { default as Footer } from "./Footer";
+export { default as LanguageSwitcher } from "./LanguageSwitcher";
 export { default as Navbar } from "./Navbar";
 export { default as Spinner } from "./Spinner";


### PR DESCRIPTION
Adds a compact DE/FR/IT picker beside the dark-mode switch in the settings dropdown.

The app has shipped four locales for a long time with no in-app way to change language — the only routes were the `?lang=` querystring or clearing site data to re-trigger browser detection.

## The control

A **segmented control**, not a cycling toggle like the dark-mode switch next to it. With two states a toggle is fine; with three, cycling makes reaching the third a guessing game, and the language currently in effect is worth showing rather than leaving the user to infer it from the surrounding text.

```
🌐  [ DE ][ FR ][ IT ]
```

Built from Bulma's `buttons has-addons are-small`, so it inherits the existing button styling and theming rather than introducing new CSS. One `mb-0` is needed because Bulma's `.buttons` carries a bottom margin meant for standalone groups, which otherwise misaligns the group against the icon.

**English is excluded**, as requested. It is also the right call independently: the BABS symbol catalogue has no English labels — `resolveBabsLang` maps anything unknown onto German — so an English UI is half translated. It stays reachable via `?lang=en` for anyone who wants it.

## Details worth a second look

**Autonyms, not translated names.** The accessible name of each button is `Deutsch` / `Français` / `Italiano`, not a name translated into the current UI language. A language picker that names languages in a language you may not read is not much use, and this is the near-universal convention. The visible label is the abbreviation, so the autonym lives in `aria-label`; `lang=` on each button stops a screen reader pronouncing "Français" with English phonetics. Each abbreviation is also a prefix of its autonym, so WCAG 2.5.3 (Label in Name) holds.

**`aria-pressed`, not `aria-current`.** These are toggle buttons, not navigation, so a screen reader announces which language is in effect.

**Matches on `resolvedLanguage`, not `language`.** i18next collapses regional variants, so a `de-CH` browser — the common case for this audience — marks the German button active instead of leaving the control looking broken with nothing selected.

**A language outside the three highlights nothing.** An English browser resolves to `en`, and no button reads as active. That is deliberate: clicking any button moves to a supported language, whereas pretending German is active would contradict the text on screen. Flagging it because it is the one visible consequence of excluding English — adding `en` to the `LANGUAGES` array is a one-line change if you would rather it never happen.

**No persistence work needed.** `i18next-browser-languagedetector` is already configured to cache to session and local storage on change (`i18n/index.ts`), so the choice survives a reload without touching the detection config.

## Also in here

`Navbar.test.tsx` mocked `react-i18next` with only `t`. The switcher reads `i18n` off the same hook, so every navbar render threw `Cannot read properties of undefined (reading 'resolvedLanguage')` — 5 failures. The mock now supplies `i18n` too.

## Verified

| check | result |
|---|---|
| `yarn test --run` | 172 passed, 17 files — includes 7 new |
| `npx tsc --noEmit` | 111 errors, **unchanged** from `develop` baseline (measured by stashing) |
| `yarn lint` | 0 errors |
| `yarn build` | clean |

The 7 new tests cover: the three languages are offered and English is not (asserting exactly 3 buttons, so adding a language is a deliberate change); clicking switches; only the active button is pressed; a regional variant resolves to its base; clicking the active language is a no-op; nothing is active for an unsupported language; and each button carries `lang=` with the autonym as its accessible name.

Rendered markup was also inspected directly to confirm the classes land where intended (`is-primary is-selected` on the active button only) — the part tests cannot judge.
