### PR TITLE
feat(map): add Trümmerbereich line type and Überschwemmtes Gebiet zone

### DIFF
--- a/ui/src/components/babs/excludedIcons.ts
+++ b/ui/src/components/babs/excludedIcons.ts
@@ -55,6 +55,8 @@ export const EXCLUDED_BABS_ICON_IDS: ReadonlySet<BabsIconId> = new Set<BabsIconI
   "1203", // Str unpassierbar - gesperrt
   "1111a", // Brandübergriffsgefahr - Signatur
   "1111b", // Brandübergriff erfolgt - Signatur
+  "1116a", // Trümmerbereich - Signatur
+  "1116b", // Trümmerbereich - Beispiel, the line controller's thumbnail
 
   // Catalogue illustrations: a "Beispiel" shows how a "Signatur" is used on a map, so it
   // is documentation rather than a symbol to place.
@@ -65,8 +67,6 @@ export const EXCLUDED_BABS_ICON_IDS: ReadonlySet<BabsIconId> = new Set<BabsIconI
   "1107b", // Brand mehrerer Gebäude - Beispiel
   "1108", // Brandübergriffsgefahr - Beispiel
   "1109", // Brandübergriff erfolgt - Beispiel
-  "1116a", // Trümmerbereich - Signatur
-  "1116b", // Trümmerbereich - Beispiel
   "2109b", // Gefahrentafel mit UN-Nummer
 ]);
 

--- a/ui/src/components/babs/lineAndZoneTypes.ts
+++ b/ui/src/components/babs/lineAndZoneTypes.ts
@@ -73,6 +73,20 @@ export const ZoneTypes: SelectableTypes = {
     outlineOnly: true,
     color: Colors.Red,
   },
+  /**
+   * Flooded area: the same red outline as Schadengebiet, plus a flow-direction arrow
+   * generated from the ring's last segment (see `EnrichPolygonMap`).
+   *
+   * The arrow is part of the symbol rather than decoration — the catalogue names it, 1115
+   * being "Zone inondée *avec direction du flux*" — which is why it is generated instead of
+   * left to the user, exactly as 1113 "avec direction" is for Rutschgebiet.
+   */
+  UeberschwemmtesGebiet: {
+    name: "UeberschwemmtesGebiet",
+    thumbnail: "1115", // Überschwemmtes Gebiet
+    outlineOnly: true,
+    color: Colors.Red,
+  },
   Brandzone: {
     name: "Brandzone",
     thumbnail: "1110", // Brandzone Flächenbrand
@@ -138,6 +152,15 @@ export const LineTypes: SelectableTypes = {
   Rutschgebiet: {
     name: "Rutschgebiet",
     thumbnail: "1113",
+    color: Colors.Red,
+  },
+  /**
+   * Debris field. A plain solid boundary: 1116 ships no pattern tile in the catalogue, and
+   * the symbol is an outline rather than a hatch, so it takes no cap and no arrowhead.
+   */
+  Truemmerbereich: {
+    name: "Truemmerbereich",
+    thumbnail: "1116b",
     color: Colors.Red,
   },
   begehbar: {

--- a/ui/src/components/map/EnrichedLayerFeatures.test.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.test.tsx
@@ -102,7 +102,7 @@ describe("EnrichedLayerFeatures", () => {
     expect(container).toBeTruthy();
   });
 
-  it("filters out deleted features and the selected feature", () => {
+  it("filters out deleted features but keeps the selected one", () => {
     const { container } = renderWithMap(
       <EnrichedFeaturesSource
         id="test"
@@ -111,6 +111,13 @@ describe("EnrichedLayerFeatures", () => {
       />,
     );
     expect(container).toBeTruthy();
+  });
+
+  it("still enriches a feature while it is selected", () => {
+    // The indicator used to vanish for exactly as long as you were editing the geometry that
+    // determines it, which is when it is most useful to see.
+    const [selected] = baseFeatureCollection.features;
+    expect(enrichFeature(selected).length).toBeGreaterThan(0);
   });
 
   it("handles empty featureCollection", () => {
@@ -281,8 +288,11 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
     [8.1, 47.0],
     [8.0, 47.0],
   ];
-  /** Middle of the eastern edge — the last segment drawn, so where the arrow springs from. */
-  const LAST_EDGE_MIDPOINT: Position = [8.1, 47.025];
+  /**
+   * Middle of the southern edge. That edge closes the ring — last vertex back to the first —
+   * which is the one the arrow springs from.
+   */
+  const CLOSING_EDGE_MIDPOINT: Position = [8.05, 47.0];
 
   const flooded = (coordinates: Position[][], color?: string): Feature<Polygon> => ({
     type: "Feature",
@@ -293,10 +303,10 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
 
   const parts = (coordinates: Position[][], color?: string) => {
     const enriched = enrichFeature(flooded(coordinates, color));
+    const lines = enriched.filter((f) => f.geometry.type === "LineString");
     return {
-      shaft: enriched.find((f) => f.geometry.type === "LineString") as
-        | Feature<LineString>
-        | undefined,
+      shaft: lines.find((f) => !String(f.id).endsWith("-edge")) as Feature<LineString> | undefined,
+      edge: lines.find((f) => String(f.id).endsWith("-edge")) as Feature<LineString> | undefined,
       head: enriched.find((f) => f.geometry.type === "Point") as Feature<Point> | undefined,
     };
   };
@@ -304,34 +314,33 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
   const shaftOf = (coordinates: Position[][]) =>
     (parts(coordinates).shaft as Feature<LineString>).geometry.coordinates;
 
-  it("springs from the middle of the last segment, not the closing repeat", () => {
-    // The ring ends with a copy of its first position; reading that as the last segment
-    // would put every arrow on the southern edge regardless of where drawing stopped.
+  it("springs from the middle of the closing edge", () => {
+    // Not from a vertex, and not from the duplicated closing position the ring ends with.
     const [tail] = shaftOf([square]);
-    expect(tail[0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
-    expect(tail[1]).toBeCloseTo(LAST_EDGE_MIDPOINT[1], 4);
+    expect(tail[0]).toBeCloseTo(CLOSING_EDGE_MIDPOINT[0], 4);
+    expect(tail[1]).toBeCloseTo(CLOSING_EDGE_MIDPOINT[1], 4);
   });
 
   it("touches the outline, unlike the slide arrow which is held clear of its line", () => {
-    // The tail sits exactly on the eastern edge, at longitude 8.1.
+    // The tail sits exactly on the southern edge, at latitude 47.0.
     const [tail] = shaftOf([square]);
-    expect(tail[0]).toBeCloseTo(8.1, 5);
+    expect(tail[1]).toBeCloseTo(47.0, 4);
   });
 
-  it("leaves the last segment at a right angle, pointing out of the zone", () => {
-    // The last segment runs due south down the eastern edge, so the outward normal is east.
+  it("leaves the closing edge at a right angle, pointing out of the zone", () => {
+    // The closing edge is the southern one, so the outward normal is due south.
     const [tail, tip] = shaftOf([square]);
-    expect(bearing(tail, tip)).toBeCloseTo(90, 1);
-    expect(tip[0]).toBeGreaterThan(8.1);
+    expect(Math.abs(bearing(tail, tip))).toBeCloseTo(180, 1);
+    expect(tip[1]).toBeLessThan(47.0);
   });
 
   it("takes the outward normal whichever way the ring is wound", () => {
-    // Same square traced counter-clockwise, which makes the northern edge the last one
-    // drawn. Outward is then north — a winding-blind rule would send it south, into the zone.
+    // Traced counter-clockwise the closing edge becomes the western one, so outward flips to
+    // west. A winding-blind rule would send it east, into the zone.
     const [tail, tip] = shaftOf([[...square].reverse()]);
-    expect(tail[1]).toBeCloseTo(47.05, 4);
-    expect(bearing(tail, tip)).toBeCloseTo(0, 1);
-    expect(tip[1]).toBeGreaterThan(47.05);
+    expect(tail[0]).toBeCloseTo(8.0, 4);
+    expect(bearing(tail, tip)).toBeCloseTo(-90, 1);
+    expect(tip[0]).toBeLessThan(8.0);
   });
 
   it("aims the chevron down the shaft", () => {
@@ -344,7 +353,8 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
   });
 
   it("moves with the vertex drawing stopped on", () => {
-    // Same square, traced from the north-west corner so it ends on the south-west one.
+    // Same square, traced from the north-west corner so it ends on the south-west one. The
+    // closing edge is then the western one, and the arrow follows it there.
     const shifted: Position[] = [
       [8.0, 47.05],
       [8.1, 47.05],
@@ -352,10 +362,10 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
       [8.0, 47.0],
       [8.0, 47.05],
     ];
-    // Ends on the south-west corner, so the last segment is the southern edge.
-    const [tail] = shaftOf([shifted]);
-    expect(tail[0]).toBeCloseTo(8.05, 4);
-    expect(tail[1]).toBeCloseTo(47.0, 4);
+    const [tail, tip] = shaftOf([shifted]);
+    expect(tail[0]).toBeCloseTo(8.0, 4);
+    expect(tail[1]).toBeCloseTo(47.025, 4);
+    expect(tip[0]).toBeLessThan(8.0);
   });
 
   it("reads the outer ring only, ignoring holes", () => {
@@ -368,8 +378,19 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
     ];
     const enriched = enrichFeature(flooded([square, hole]));
     // One shaft and one head — an arrow off the hole would point into the zone.
-    expect(enriched).toHaveLength(2);
-    expect(shaftOf([square, hole])[0][0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
+    // Emphasised edge, shaft and head — an arrow off the hole would double that.
+    expect(enriched).toHaveLength(3);
+    expect(shaftOf([square, hole])[0][1]).toBeCloseTo(CLOSING_EDGE_MIDPOINT[1], 4);
+  });
+
+  it("redraws the closing edge heavier, so the arrow's edge is visible while editing", () => {
+    const { edge } = parts([square]);
+    // Spans the closing edge exactly: south-east corner back to the south-west one.
+    expect(edge?.geometry.coordinates).toEqual([
+      [8.1, 47.0],
+      [8.0, 47.0],
+    ]);
+    expect(edge?.properties?.width).toBeGreaterThan(2);
   });
 
   it("gives a multipart zone one arrow per part, with distinct ids", () => {
@@ -381,8 +402,10 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
       properties: { zoneType: "UeberschwemmtesGebiet", deletedAt: null },
     } as Feature<MultiPolygon>);
     expect(enriched.map((f) => f.id)).toEqual([
+      "zone-1:flow-0-edge",
       "zone-1:flow-0",
       "zone-1:flow-0-tip",
+      "zone-1:flow-1-edge",
       "zone-1:flow-1",
       "zone-1:flow-1-tip",
     ]);
@@ -395,15 +418,15 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
       [8.1, 47.0],
       [8.0, 47.0],
     ];
-    // Last segment runs from the apex down to the south-east corner.
+    // Closing edge runs from the south-east corner back to the south-west one.
     const [tail] = shaftOf([triangle]);
-    expect(tail[0]).toBeCloseTo(8.075, 3);
-    expect(tail[1]).toBeCloseTo(47.025, 3);
+    expect(tail[0]).toBeCloseTo(8.05, 3);
+    expect(tail[1]).toBeCloseTo(47.0, 3);
   });
 
-  it("ignores a repeated final vertex rather than aiming due north", () => {
-    // `bearing(p, p)` is 0, not NaN, so a duplicate would silently point the arrow north —
-    // a plausible-looking wrong answer rather than a visible failure.
+  it("is unmoved by a repeated vertex", () => {
+    // `bearing(p, p)` is 0 rather than NaN, so a duplicate that reached the bearing would
+    // silently aim the arrow north — a plausible-looking wrong answer, not a visible failure.
     const duplicated: Position[] = [
       [8.0, 47.0],
       [8.0, 47.05],
@@ -413,8 +436,9 @@ describe("Überschwemmtes Gebiet flow arrow", () => {
       [8.0, 47.0],
     ];
     const [tail, tip] = shaftOf([duplicated]);
-    expect(tail[0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
-    expect(bearing(tail, tip)).toBeCloseTo(90, 1);
+    expect(tail[0]).toBeCloseTo(CLOSING_EDGE_MIDPOINT[0], 4);
+    expect(tail[1]).toBeCloseTo(CLOSING_EDGE_MIDPOINT[1], 4);
+    expect(Math.abs(bearing(tail, tip))).toBeCloseTo(180, 1);
   });
 
   it("emits nothing when the ring encloses nothing", () => {

--- a/ui/src/components/map/EnrichedLayerFeatures.test.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.test.tsx
@@ -102,13 +102,9 @@ describe("EnrichedLayerFeatures", () => {
     expect(container).toBeTruthy();
   });
 
-  it("filters out deleted features but keeps the selected one", () => {
+  it("filters out deleted features", () => {
     const { container } = renderWithMap(
-      <EnrichedFeaturesSource
-        id="test"
-        featureCollection={baseFeatureCollection}
-        selectedFeature="line-1"
-      />,
+      <EnrichedFeaturesSource id="test" featureCollection={baseFeatureCollection} />,
     );
     expect(container).toBeTruthy();
   });

--- a/ui/src/components/map/EnrichedLayerFeatures.test.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.test.tsx
@@ -5,8 +5,12 @@ import { Map as MapLibre } from "react-map-gl/maplibre";
 import { MapStyles } from "views/map/controls/StyleController";
 import { describe, expect, it, vi } from "vitest";
 import bearing from "@turf/bearing";
-import type { Feature, LineString, Point, Position } from "geojson";
-import { enrichFeature, EnrichedFeaturesSource } from "./EnrichedLayerFeatures";
+import type { Feature, LineString, MultiPolygon, Point, Polygon, Position } from "geojson";
+import {
+  enrichFeature,
+  EnrichedFeaturesSource,
+  EnrichLineStringMap,
+} from "./EnrichedLayerFeatures";
 
 vi.mock("react-map-gl/maplibre", () => ({
   Map: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
@@ -233,6 +237,20 @@ describe("Rutschgebiet slide arrow", () => {
     ).toEqual([]);
   });
 
+  it("leaves Trümmerbereich uncapped, so it draws as a plain solid line", () => {
+    // 1116 has no pattern tile and the symbol is a plain boundary, so "no arrowhead" is
+    // expressed by absence from the enrichment map rather than by a config flag.
+    expect(EnrichLineStringMap.Truemmerbereich).toBeUndefined();
+    expect(
+      enrichFeature({
+        type: "Feature",
+        id: "debris-1",
+        geometry: { type: "LineString", coordinates: uShape },
+        properties: { lineType: "Truemmerbereich", deletedAt: null },
+      }),
+    ).toEqual([]);
+  });
+
   it("leaves cap-only line types without a shaft", () => {
     const enriched = enrichFeature({
       type: "Feature",
@@ -242,5 +260,190 @@ describe("Rutschgebiet slide arrow", () => {
     });
     expect(enriched).toHaveLength(2);
     expect(enriched.every((f) => f.geometry.type === "Point")).toBe(true);
+  });
+});
+
+/**
+ * The flow arrow is the polygon counterpart of the slide arrow, and the first enrichment
+ * keyed on `zoneType` rather than `lineType`. Its anchor is derived from draw order, which
+ * nothing else in the app depends on, so these tests are the only thing pinning it.
+ */
+describe("Überschwemmtes Gebiet flow arrow", () => {
+  /**
+   * A square traced clockwise from the south-west corner, with the closing repeat
+   * mapbox-gl-draw adds. The last drawn vertex is the south-east corner and the last
+   * segment runs due south down the eastern edge, so the outward normal is due east.
+   */
+  const square: Position[] = [
+    [8.0, 47.0],
+    [8.0, 47.05],
+    [8.1, 47.05],
+    [8.1, 47.0],
+    [8.0, 47.0],
+  ];
+  /** Middle of the eastern edge — the last segment drawn, so where the arrow springs from. */
+  const LAST_EDGE_MIDPOINT: Position = [8.1, 47.025];
+
+  const flooded = (coordinates: Position[][], color?: string): Feature<Polygon> => ({
+    type: "Feature",
+    id: "zone-1",
+    geometry: { type: "Polygon", coordinates },
+    properties: { zoneType: "UeberschwemmtesGebiet", deletedAt: null, ...(color ? { color } : {}) },
+  });
+
+  const parts = (coordinates: Position[][], color?: string) => {
+    const enriched = enrichFeature(flooded(coordinates, color));
+    return {
+      shaft: enriched.find((f) => f.geometry.type === "LineString") as
+        | Feature<LineString>
+        | undefined,
+      head: enriched.find((f) => f.geometry.type === "Point") as Feature<Point> | undefined,
+    };
+  };
+
+  const shaftOf = (coordinates: Position[][]) =>
+    (parts(coordinates).shaft as Feature<LineString>).geometry.coordinates;
+
+  it("springs from the middle of the last segment, not the closing repeat", () => {
+    // The ring ends with a copy of its first position; reading that as the last segment
+    // would put every arrow on the southern edge regardless of where drawing stopped.
+    const [tail] = shaftOf([square]);
+    expect(tail[0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
+    expect(tail[1]).toBeCloseTo(LAST_EDGE_MIDPOINT[1], 4);
+  });
+
+  it("touches the outline, unlike the slide arrow which is held clear of its line", () => {
+    // The tail sits exactly on the eastern edge, at longitude 8.1.
+    const [tail] = shaftOf([square]);
+    expect(tail[0]).toBeCloseTo(8.1, 5);
+  });
+
+  it("leaves the last segment at a right angle, pointing out of the zone", () => {
+    // The last segment runs due south down the eastern edge, so the outward normal is east.
+    const [tail, tip] = shaftOf([square]);
+    expect(bearing(tail, tip)).toBeCloseTo(90, 1);
+    expect(tip[0]).toBeGreaterThan(8.1);
+  });
+
+  it("takes the outward normal whichever way the ring is wound", () => {
+    // Same square traced counter-clockwise, which makes the northern edge the last one
+    // drawn. Outward is then north — a winding-blind rule would send it south, into the zone.
+    const [tail, tip] = shaftOf([[...square].reverse()]);
+    expect(tail[1]).toBeCloseTo(47.05, 4);
+    expect(bearing(tail, tip)).toBeCloseTo(0, 1);
+    expect(tip[1]).toBeGreaterThan(47.05);
+  });
+
+  it("aims the chevron down the shaft", () => {
+    const { shaft, head } = parts([square]);
+    const [tail, tip] = (shaft as Feature<LineString>).geometry.coordinates;
+    const rotation = head?.properties?.iconRotation as number;
+    const aimed = (((rotation + 90) % 360) + 360) % 360;
+    const wanted = ((bearing(tail, tip) % 360) + 360) % 360;
+    expect(aimed).toBeCloseTo(wanted, 1);
+  });
+
+  it("moves with the vertex drawing stopped on", () => {
+    // Same square, traced from the north-west corner so it ends on the south-west one.
+    const shifted: Position[] = [
+      [8.0, 47.05],
+      [8.1, 47.05],
+      [8.1, 47.0],
+      [8.0, 47.0],
+      [8.0, 47.05],
+    ];
+    // Ends on the south-west corner, so the last segment is the southern edge.
+    const [tail] = shaftOf([shifted]);
+    expect(tail[0]).toBeCloseTo(8.05, 4);
+    expect(tail[1]).toBeCloseTo(47.0, 4);
+  });
+
+  it("reads the outer ring only, ignoring holes", () => {
+    const hole: Position[] = [
+      [8.02, 47.01],
+      [8.02, 47.02],
+      [8.03, 47.02],
+      [8.03, 47.01],
+      [8.02, 47.01],
+    ];
+    const enriched = enrichFeature(flooded([square, hole]));
+    // One shaft and one head — an arrow off the hole would point into the zone.
+    expect(enriched).toHaveLength(2);
+    expect(shaftOf([square, hole])[0][0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
+  });
+
+  it("gives a multipart zone one arrow per part, with distinct ids", () => {
+    const second = square.map(([lon, lat]) => [lon + 1, lat] as Position);
+    const enriched = enrichFeature({
+      type: "Feature",
+      id: "zone-1",
+      geometry: { type: "MultiPolygon", coordinates: [[square], [second]] },
+      properties: { zoneType: "UeberschwemmtesGebiet", deletedAt: null },
+    } as Feature<MultiPolygon>);
+    expect(enriched.map((f) => f.id)).toEqual([
+      "zone-1:flow-0",
+      "zone-1:flow-0-tip",
+      "zone-1:flow-1",
+      "zone-1:flow-1-tip",
+    ]);
+  });
+
+  it("handles a triangle", () => {
+    const triangle: Position[] = [
+      [8.0, 47.0],
+      [8.05, 47.05],
+      [8.1, 47.0],
+      [8.0, 47.0],
+    ];
+    // Last segment runs from the apex down to the south-east corner.
+    const [tail] = shaftOf([triangle]);
+    expect(tail[0]).toBeCloseTo(8.075, 3);
+    expect(tail[1]).toBeCloseTo(47.025, 3);
+  });
+
+  it("ignores a repeated final vertex rather than aiming due north", () => {
+    // `bearing(p, p)` is 0, not NaN, so a duplicate would silently point the arrow north —
+    // a plausible-looking wrong answer rather than a visible failure.
+    const duplicated: Position[] = [
+      [8.0, 47.0],
+      [8.0, 47.05],
+      [8.1, 47.05],
+      [8.1, 47.0],
+      [8.1, 47.0],
+      [8.0, 47.0],
+    ];
+    const [tail, tip] = shaftOf([duplicated]);
+    expect(tail[0]).toBeCloseTo(LAST_EDGE_MIDPOINT[0], 4);
+    expect(bearing(tail, tip)).toBeCloseTo(90, 1);
+  });
+
+  it("emits nothing when the ring encloses nothing", () => {
+    expect(
+      enrichFeature(
+        flooded([
+          [
+            [8.0, 47.0],
+            [8.0, 47.0],
+            [8.0, 47.0],
+          ],
+        ]),
+      ),
+    ).toEqual([]);
+  });
+
+  it("carries the feature's own colour", () => {
+    const { shaft, head } = parts([square], "#123456");
+    expect(shaft?.properties?.color).toBe("#123456");
+    expect(head?.properties?.icon).toContain("chevron-red");
+  });
+
+  it("leaves other zone types alone, so the registry gates it rather than the geometry", () => {
+    const enriched = enrichFeature({
+      type: "Feature",
+      id: "zone-2",
+      geometry: { type: "Polygon", coordinates: [square] },
+      properties: { zoneType: "Schadengebiet", deletedAt: null },
+    });
+    expect(enriched).toEqual([]);
   });
 });

--- a/ui/src/components/map/EnrichedLayerFeatures.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.tsx
@@ -10,6 +10,7 @@ import { markerSpriteKey } from "@f-eld-ch/babs-core";
 import { babsImage } from "components/babs/iconResolver";
 import { Colors } from "components/babs/lineAndZoneTypes";
 import type { Feature, FeatureCollection, GeoJsonProperties, Geometry, Position } from "geojson";
+import { useMemo } from "react";
 import { Layer, Source } from "react-map-gl/maplibre";
 
 /** Shaft length as a fraction of the parent line's length. */
@@ -76,6 +77,16 @@ const FLOW_ARROW_MIN_KM = 0.01;
 const FLOW_ARROW_MAX_KM = 0.17;
 /** Below this a ring is a stray click, with no extent to scale an arrow against. */
 const FLOW_MIN_EXTENT_KM = 1e-6;
+/**
+ * Stroke width for the stretch of outline the arrow springs from, against the 2px every
+ * other line is drawn at.
+ *
+ * This is the thickened-outline half of the catalogue's 1115, and it doubles as the answer
+ * to "which edge is the arrow attached to" while the zone is being edited — mapbox-gl-draw
+ * tags vertices with a `coord_path` whose last index depends on the vertex count, so the
+ * closing edge's endpoints cannot be picked out by a style filter.
+ */
+const FLOW_EDGE_WIDTH = 4;
 /**
  * As `SLIDE_SELF_CROSSING_RATIO`, but load-bearing rather than defensive: the flow arrow's
  * anchor *is* a ring vertex, so the ray leaves through the boundary by construction and
@@ -246,13 +257,17 @@ const ringWinding = (ring: Position[]): number => {
 };
 
 /**
- * The flow-direction arrow: a straight shaft springing from the last vertex of the outer
- * ring, leaving it at a right angle to the last segment drawn, tipped with a chevron.
+ * The flow-direction arrow: a straight shaft springing from the middle of the outer ring's
+ * closing edge, leaving it at a right angle, tipped with a chevron.
  *
- * Direction comes from where the user stopped drawing — an input they already control — so
- * nothing extra has to be persisted. Unlike the slide arrow the tail sits *on* the boundary:
- * a polygon stroke is 2px, so there is no pattern band to clear, and springing from the
- * outline is what makes the arrow read as belonging to it.
+ * The closing edge — last vertex back to the first — is the one the user never clicks: it
+ * appears when the ring closes. That makes it the easiest to predict while drawing and the
+ * easiest to aim afterwards, since moving either of its two endpoints swings the arrow.
+ * Nothing extra has to be persisted as a result.
+ *
+ * Unlike the slide arrow the tail sits *on* the boundary: a polygon stroke is 2px, so there
+ * is no pattern band to clear, and springing from the outline is what makes the arrow read
+ * as belonging to it.
  */
 const buildFlowArrow = (
   parentId: Feature["id"],
@@ -269,31 +284,22 @@ const buildFlowArrow = (
     return [];
   }
 
-  const anchor = open[open.length - 1];
-  // Walk back past any repeated vertex: `bearing` between two identical positions is 0, not
-  // NaN, so without this every such arrow would quietly point due north instead of failing.
-  let prior = open.length - 2;
-  while (prior >= 0 && samePosition(open[prior], anchor)) {
-    prior -= 1;
-  }
-  if (prior < 0) {
-    return [];
-  }
+  // The closing edge, running from the last vertex back to the first. `openRing` guarantees
+  // those two differ, so the edge always has a direction.
+  const from = open[open.length - 1];
+  const to = open[0];
+  const alongClosingEdge = bearing(point(from), point(to));
 
-  // At a right angle to the last segment, on whichever side lies outside the ring. Taken
-  // from the winding rather than probed with a containment test, which would be ambiguous
-  // here: the anchor is a corner, so a point offset from it can fall either side depending
-  // on how sharp the corner is.
-  const alongLastSegment = bearing(point(open[prior]), point(anchor));
-  const flowBearing = alongLastSegment + (ringWinding(open) > 0 ? 90 : -90);
+  // At a right angle to that edge, on whichever side lies outside the ring. The side comes
+  // from the winding rather than from a containment probe: only the sign of the signed area
+  // is needed, which is exact, where a probe offset from the boundary can land either side.
+  const flowBearing = alongClosingEdge + (ringWinding(open) > 0 ? 90 : -90);
 
-  // Springs from the middle of the last segment rather than from its end vertex. A corner is
-  // shared by two edges, so an arrow planted there reads as belonging to neither; the middle
-  // of an edge is unambiguous, and the perpendicular genuinely separates inside from out.
-  const segment = distance(point(open[prior]), point(anchor), { units: "kilometers" });
-  const base = destination(point(open[prior]), segment / 2, alongLastSegment, {
-    units: "kilometers",
-  });
+  // Springs from the middle of the edge rather than from a vertex. A corner is shared by two
+  // edges, so an arrow planted there reads as belonging to neither, and the perpendicular at
+  // a corner does not cleanly separate inside from out.
+  const segment = distance(point(from), point(to), { units: "kilometers" });
+  const base = destination(point(from), segment / 2, alongClosingEdge, { units: "kilometers" });
   const tail = base.geometry.coordinates;
 
   // Measured against the *closed* ring: the segment from the last vertex back to the first
@@ -324,16 +330,26 @@ const buildFlowArrow = (
   const span = crossings.length > 0 ? Math.min(nominal, ...crossings) : nominal;
 
   const tip = destination(base, span, flowBearing, { units: "kilometers" });
+  const color = featureColor ?? config.color;
 
-  return arrowFeatures(
-    parentId,
-    kind,
-    tail,
-    tip.geometry.coordinates,
-    flowBearing,
-    config.icon,
-    featureColor ?? config.color,
-  );
+  // The closing edge itself, redrawn heavier. Emitted before the shaft so the shaft paints
+  // over the join rather than being cut by it.
+  const edge = lineString([from, to]);
+  edge.id = `${parentId}:${kind}-edge`;
+  edge.properties = { parent: parentId, color, width: FLOW_EDGE_WIDTH };
+
+  return [
+    edge,
+    ...arrowFeatures(
+      parentId,
+      kind,
+      tail,
+      tip.geometry.coordinates,
+      flowBearing,
+      config.icon,
+      color,
+    ),
+  ];
 };
 
 const enrichFeature = (
@@ -573,12 +589,21 @@ const EnrichedSymbolSource = (props: EnrichedFeaturesProps) => {
     type: "FeatureCollection",
     features: [],
   };
-  enrichedFC.features = Object.assign(
-    [],
-    featureCollection.features
-      .filter((f) => f.properties?.deletedAt === null)
-      .filter((f) => f.id !== props.selectedFeature)
-      .flatMap((f) => enrichFeature(f)),
+  // The selected feature is enriched too. It used to be skipped, which meant the indicator
+  // vanished for exactly as long as you were editing the geometry that determines it — and
+  // the flow arrow is aimed by dragging vertices, so that is when seeing it matters most.
+  // These are synthetic features in their own source, so they do not collide with the
+  // active-state styling mapbox-gl-draw puts on the feature itself.
+  //
+  // Memoised because on the active layer this now runs against a collection that changes on
+  // every animation frame of a vertex drag (see `useLiveDrawGeometry` in Map.tsx), rather
+  // than once per save.
+  enrichedFC.features = useMemo(
+    () =>
+      featureCollection.features
+        .filter((f) => f.properties?.deletedAt === null)
+        .flatMap((f) => enrichFeature(f)),
+    [featureCollection],
   );
 
   return (
@@ -601,7 +626,9 @@ const EnrichedSymbolSource = (props: EnrichedFeaturesProps) => {
         paint={{
           "line-color": ["coalesce", ["get", "color"], "#000000"],
           "line-opacity": 0.7,
-          "line-width": 2,
+          // Data-driven so the emphasised stretch of outline can share this layer with the
+          // arrow shafts instead of needing one of its own.
+          "line-width": ["coalesce", ["get", "width"], 2],
         }}
       />
       <Layer

--- a/ui/src/components/map/EnrichedLayerFeatures.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.tsx
@@ -1,619 +1,48 @@
-import along from "@turf/along";
-import bbox from "@turf/bbox";
-import bearing from "@turf/bearing";
-import destination from "@turf/destination";
-import distance from "@turf/distance";
-import { lineString, point } from "@turf/helpers";
-import turfLength from "@turf/length";
-import lineIntersect from "@turf/line-intersect";
-import { markerSpriteKey } from "@f-eld-ch/babs-core";
-import { babsImage } from "components/babs/iconResolver";
-import { Colors } from "components/babs/lineAndZoneTypes";
-import type { Feature, FeatureCollection, GeoJsonProperties, Geometry, Position } from "geojson";
+import type { FeatureCollection } from "geojson";
 import { useMemo } from "react";
 import { Layer, Source } from "react-map-gl/maplibre";
+import { ARROW } from "./enrichment/arrow";
+import { enrichFeature } from "./enrichment/enrichFeature";
+import { EnrichLineStringMap, EnrichPolygonMap } from "./enrichment/registry";
 
-/** Shaft length as a fraction of the parent line's length. */
-const SLIDE_ARROW_LENGTH_RATIO = 0.25;
-/** Clamps on that fraction, so a hand-drawn stub still shows and a long boundary stays readable. */
-const SLIDE_ARROW_MIN_KM = 0.025;
-const SLIDE_ARROW_MAX_KM = 0.5;
 /**
- * How far either side of the midpoint the local bearing is measured, as a fraction of the
- * line's length. Taken across a span rather than between the two vertices flanking the
- * midpoint so a kink landing exactly there does not swing the arrow off the perpendicular.
- */
-const SLIDE_BEARING_SPAN = 0.05;
-/**
- * Which perpendicular the arrow occupies, as a signed multiple of 90° on the local bearing:
- * -1 is the left of travel, +1 the right.
+ * An overlay of features derived from the active layer's own geometry — arrowheads, direction
+ * indicators, emphasised stretches of outline.
  *
- * Fixed to the draw direction, not derived from the shape. maplibre's line bucket extrudes
- * its `up = false` half-vertex along `perp(direction)`, and the line-pattern fragment shader
- * maps that vertex to texture y = 0 — the top row of the tile. Tile space is y-down, so for
- * an eastward line that is south: the top of a pattern tile always lands on the right of
- * travel. The `1113-pattern` tile carries its teeth in those top rows, so the teeth fall on
- * the right of travel, and the arrow shares that side — set by eye against the rendered
- * symbol, so flip this one constant if it ever needs to go the other way.
+ * These are the parts of a BABS symbol the catalogue defines but GeoJSON cannot express. They
+ * are rebuilt on every render and never persisted, and they live in their own source, so they
+ * neither collide with the draw layers nor need a `styleGenerator` entry: the layers here are
+ * the only ones that ever see them.
  *
- * Tying the arrow to draw direction rather than to curvature is what makes reversing a
- * linestring mirror the whole symbol at once, teeth and arrow together — which is how the
- * mirrored line type came to be retired.
+ * The geometry itself is built in `./enrichment`; this file is only the rendering.
  */
-const SLIDE_ARROW_SIDE = 1;
-/**
- * Clear space left between the boundary and each end of the arrow, as a fraction of the
- * span available to it. The arrow annotates the boundary rather than touching it, and the
- * pattern band it sits against is drawn up to 22px wide, so a shaft flush with the line
- * disappears into it.
- */
-const SLIDE_ARROW_GAP_RATIO = 0.12;
-/** Below this a line is a stray click, not a boundary: `along` degenerates and the bearing is noise. */
-const SLIDE_MIN_LINE_KM = 1e-6;
-/**
- * Crossings nearer than this fraction of the arrow's nominal length are the boundary the
- * arrow springs from, not the far side of a bend.
- *
- * The midpoint is found along a great circle while the boundary is drawn as a planar chord,
- * so on a straight line the two miss each other by a metre or so and the ray re-crosses its
- * own boundary almost immediately. Discounting only an exact zero left the arrow truncated
- * to that metre, which is the common case rendered invisible.
- */
-const SLIDE_SELF_CROSSING_RATIO = 0.1;
-/**
- * Flow-arrow shaft length, as a fraction of the outer ring's bounding-box diagonal.
- *
- * Deliberately not the perimeter, which would be the obvious analogue of the slide arrow's
- * `total`: perimeter grows with how finely the boundary was digitised, so a flood zone
- * traced along a river with two hundred vertices would get an arrow several times the size
- * of the zone it annotates. The diagonal tracks how large the zone actually looks.
- */
-const FLOW_ARROW_LENGTH_RATIO = 0.12;
-/**
- * Clamps on that fraction. Tighter than the slide arrow's: this one is a mark against one
- * edge of an area rather than a span across a line, so it reads better short.
- */
-const FLOW_ARROW_MIN_KM = 0.01;
-const FLOW_ARROW_MAX_KM = 0.17;
-/** Below this a ring is a stray click, with no extent to scale an arrow against. */
-const FLOW_MIN_EXTENT_KM = 1e-6;
-/**
- * Stroke width for the stretch of outline the arrow springs from, against the 2px every
- * other line is drawn at.
- *
- * This is the thickened-outline half of the catalogue's 1115, and it doubles as the answer
- * to "which edge is the arrow attached to" while the zone is being edited — mapbox-gl-draw
- * tags vertices with a `coord_path` whose last index depends on the vertex count, so the
- * closing edge's endpoints cannot be picked out by a style filter.
- */
-const FLOW_EDGE_WIDTH = 4;
-/**
- * As `SLIDE_SELF_CROSSING_RATIO`, but load-bearing rather than defensive: the flow arrow's
- * anchor *is* a ring vertex, so the ray leaves through the boundary by construction and
- * would otherwise be truncated to nothing.
- */
-const FLOW_SELF_CROSSING_RATIO = 0.1;
-/**
- * Two positions this close are the same vertex. Rings close by repeating their first
- * position, and finishing a polygon on top of an existing vertex leaves duplicates — both
- * make the tangent bearing meaningless. 1e-9° is well under a millimetre.
- */
-const VERTEX_EPSILON_DEG = 1e-9;
 
-/**
- * The two features every generated arrow is made of: a shaft the enriched line layer
- * strokes, and a chevron the enriched symbol layer places at its tip.
- *
- * Shared because the *contract* is shared — the `:kind` / `:kind-tip` id suffixes, `parent`,
- * and above all the rotation convention below — not because the geometry is. Each builder
- * still works out its own anchor, bearing and length; this only writes the result down.
- */
-const arrowFeatures = (
-  parentId: Feature["id"],
-  /** Distinguishes this arrow's synthetic ids from any other the parent carries. */
-  kind: string,
-  tail: Position,
-  tip: Position,
-  /** Direction of travel, tail towards tip. */
-  aim: number,
-  icon: string,
-  color: string,
-): Feature<Geometry, GeoJsonProperties>[] => {
-  const shaft = lineString([tail, tip]);
-  shaft.id = `${parentId}:${kind}`;
-  shaft.properties = { parent: parentId, color };
-
-  const head = point(tip);
-  head.id = `${parentId}:${kind}-tip`;
-  head.properties = {
-    parent: parentId,
-    icon,
-    // Minus, not plus: the chevron artwork points east and `icon-rotate` is measured
-    // clockwise from north. The end caps reach the same place via `+ offset` only because
-    // they feed in a *reversed* bearing; this one is already a direction of travel, so
-    // adding would aim the head back up its own shaft.
-    iconRotation: aim - CHEVRON_BEARING_OFFSET,
-  };
-
-  return [shaft, head];
-};
-
-/**
- * The slide-direction arrow: a straight shaft leaving the boundary's midpoint at a right
- * angle, tipped with a chevron.
- *
- * It sits on the side the pattern's teeth do not occupy (see `SLIDE_ARROW_SIDE`) and points
- * *back at* the boundary: the slide runs onto the line, so the head is the end nearest it.
- * Neither end touches — a shaft flush with the line vanishes into a pattern band drawn up
- * to 22px wide.
- */
-const buildSlideArrow = (
-  parentId: Feature["id"],
-  coordinates: Position[],
-  config: SlideArrowConfig,
-  /** The feature's own stroke colour, so a recoloured boundary keeps its arrow in step. */
-  featureColor: string | undefined,
-): Feature<Geometry, GeoJsonProperties>[] => {
-  if (coordinates.length < 2) {
-    return [];
-  }
-
-  const line = lineString(coordinates);
-  const total = turfLength(line, { units: "kilometers" });
-  // Negated so a NaN length is rejected too. Below the floor every vertex effectively
-  // coincides and there is no direction to be perpendicular to.
-  if (!(total > SLIDE_MIN_LINE_KM)) {
-    return [];
-  }
-
-  const half = total / 2;
-  const base = along(line, half, { units: "kilometers" });
-  const before = along(line, Math.max(half - total * SLIDE_BEARING_SPAN, 0), {
-    units: "kilometers",
-  });
-  const after = along(line, Math.min(half + total * SLIDE_BEARING_SPAN, total), {
-    units: "kilometers",
-  });
-  const alongBearing = bearing(before, after);
-
-  // Away from the boundary, on the side the teeth do not occupy. The arrow is then built
-  // back along this bearing, so it approaches the line rather than springing off it.
-  const slideBearing = alongBearing + SLIDE_ARROW_SIDE * 90;
-
-  // Never longer than the line it annotates, so a stray short line gets a stub rather than
-  // a spike several times its own size.
-  const nominal = Math.min(
-    Math.max(total * config.lengthRatio, Math.min(SLIDE_ARROW_MIN_KM, total)),
-    SLIDE_ARROW_MAX_KM,
-  );
-
-  // A boundary that curves back on itself — the usual shape — would otherwise have the arrow
-  // run straight across the bowl and bury its head in the pattern band on the far side. Probe
-  // along the ray and stop at the first crossing back over the boundary.
-  const reach = destination(base, nominal, slideBearing, { units: "kilometers" });
-  const crossings = lineIntersect(
-    lineString([base.geometry.coordinates, reach.geometry.coordinates]),
-    line,
-  )
-    .features.map((crossing) => distance(base, crossing, { units: "kilometers" }))
-    // The base sits on the boundary, so the ray re-crosses it immediately; ignore that.
-    .filter((km) => km > nominal * SLIDE_SELF_CROSSING_RATIO);
-  const span = crossings.length > 0 ? Math.min(nominal, ...crossings) : nominal;
-
-  // The arrow runs *towards* the boundary: the slide moves onto the line, so the head is
-  // the end nearest it. Both ends are held off — the head stops short of the line rather
-  // than touching it, and the tail stops short of whatever the probe found on the far side.
-  const gap = span * SLIDE_ARROW_GAP_RATIO;
-  const tip = destination(base, gap, slideBearing, { units: "kilometers" });
-  const tail = destination(base, span - gap, slideBearing, { units: "kilometers" });
-  // Down the shaft, from the far end back to the boundary — the reverse of `slideBearing`.
-  const aim = slideBearing + 180;
-
-  return arrowFeatures(
-    parentId,
-    "slide",
-    tail.geometry.coordinates,
-    tip.geometry.coordinates,
-    aim,
-    config.icon,
-    featureColor ?? config.color,
-  );
-};
-
-const samePosition = (a: Position, b: Position): boolean =>
-  Math.abs(a[0] - b[0]) < VERTEX_EPSILON_DEG && Math.abs(a[1] - b[1]) < VERTEX_EPSILON_DEG;
-
-/**
- * The ring with its closing repeat removed, so the last entry is the last vertex the user
- * actually placed rather than a copy of the first.
- *
- * Pops in a loop rather than dropping a single position: finishing a polygon on top of the
- * first vertex can leave more than one copy, and an import may repeat it too.
- */
-const openRing = (ring: Position[]): Position[] => {
-  const open = ring.slice();
-  while (open.length > 1 && samePosition(open[open.length - 1], open[0])) {
-    open.pop();
-  }
-  return open;
-};
-
-/**
- * Twice the signed area of a ring, by the shoelace formula. Positive means the ring is
- * wound counter-clockwise, negative clockwise.
- *
- * Only the sign is used, so working in raw degrees is fine — no projection needed. This is
- * what tells the arrow which perpendicular points out of the zone rather than into it: on a
- * counter-clockwise ring the interior lies to the left of travel, so outward is the right.
- */
-const ringWinding = (ring: Position[]): number => {
-  let doubleArea = 0;
-  for (let i = 0; i < ring.length; i += 1) {
-    const [x1, y1] = ring[i];
-    const [x2, y2] = ring[(i + 1) % ring.length];
-    doubleArea += x1 * y2 - x2 * y1;
-  }
-  return doubleArea;
-};
-
-/**
- * The flow-direction arrow: a straight shaft springing from the middle of the outer ring's
- * closing edge, leaving it at a right angle, tipped with a chevron.
- *
- * The closing edge — last vertex back to the first — is the one the user never clicks: it
- * appears when the ring closes. That makes it the easiest to predict while drawing and the
- * easiest to aim afterwards, since moving either of its two endpoints swings the arrow.
- * Nothing extra has to be persisted as a result.
- *
- * Unlike the slide arrow the tail sits *on* the boundary: a polygon stroke is 2px, so there
- * is no pattern band to clear, and springing from the outline is what makes the arrow read
- * as belonging to it.
- */
-const buildFlowArrow = (
-  parentId: Feature["id"],
-  kind: string,
-  ring: Position[],
-  config: FlowArrowConfig,
-  /** The feature's own stroke colour, so a recoloured zone keeps its arrow in step. */
-  featureColor: string | undefined,
-): Feature<Geometry, GeoJsonProperties>[] => {
-  const open = openRing(ring);
-  // Fewer than three distinct vertices enclose nothing, so there is no inside for the arrow
-  // to point out of.
-  if (open.length < 3) {
-    return [];
-  }
-
-  // The closing edge, running from the last vertex back to the first. `openRing` guarantees
-  // those two differ, so the edge always has a direction.
-  const from = open[open.length - 1];
-  const to = open[0];
-  const alongClosingEdge = bearing(point(from), point(to));
-
-  // At a right angle to that edge, on whichever side lies outside the ring. The side comes
-  // from the winding rather than from a containment probe: only the sign of the signed area
-  // is needed, which is exact, where a probe offset from the boundary can land either side.
-  const flowBearing = alongClosingEdge + (ringWinding(open) > 0 ? 90 : -90);
-
-  // Springs from the middle of the edge rather than from a vertex. A corner is shared by two
-  // edges, so an arrow planted there reads as belonging to neither, and the perpendicular at
-  // a corner does not cleanly separate inside from out.
-  const segment = distance(point(from), point(to), { units: "kilometers" });
-  const base = destination(point(from), segment / 2, alongClosingEdge, { units: "kilometers" });
-  const tail = base.geometry.coordinates;
-
-  // Measured against the *closed* ring: the segment from the last vertex back to the first
-  // is real boundary, and on a convex zone it is the one the arrow is likeliest to meet.
-  const boundary = lineString([...open, open[0]]);
-  const [minX, minY, maxX, maxY] = bbox(boundary);
-  const extent = distance(point([minX, minY]), point([maxX, maxY]), { units: "kilometers" });
-  // Negated so a NaN extent is rejected too.
-  if (!(extent > FLOW_MIN_EXTENT_KM)) {
-    return [];
-  }
-
-  // Never longer than the zone it annotates, so a hand-drawn stub gets a stub.
-  const nominal = Math.min(
-    Math.max(extent * config.lengthRatio, Math.min(FLOW_ARROW_MIN_KM, extent)),
-    FLOW_ARROW_MAX_KM,
-  );
-
-  // The outward normal is not guaranteed to stay outside — on a concave ring it can re-enter.
-  // The bearing is honoured either way, since it follows from the boundary the user drew, but
-  // the ray stops at the first crossing so a wrong-way arrow stays a local mark rather than
-  // spearing the whole zone.
-  const reach = destination(base, nominal, flowBearing, { units: "kilometers" });
-  const crossings = lineIntersect(lineString([tail, reach.geometry.coordinates]), boundary)
-    .features.map((crossing) => distance(base, crossing, { units: "kilometers" }))
-    // The tail sits on the boundary, so the ray leaves through it; ignore that crossing.
-    .filter((km) => km > nominal * FLOW_SELF_CROSSING_RATIO);
-  const span = crossings.length > 0 ? Math.min(nominal, ...crossings) : nominal;
-
-  const tip = destination(base, span, flowBearing, { units: "kilometers" });
-  const color = featureColor ?? config.color;
-
-  // The closing edge itself, redrawn heavier. Emitted before the shaft so the shaft paints
-  // over the join rather than being cut by it.
-  const edge = lineString([from, to]);
-  edge.id = `${parentId}:${kind}-edge`;
-  edge.properties = { parent: parentId, color, width: FLOW_EDGE_WIDTH };
-
-  return [
-    edge,
-    ...arrowFeatures(
-      parentId,
-      kind,
-      tail,
-      tip.geometry.coordinates,
-      flowBearing,
-      config.icon,
-      color,
-    ),
-  ];
-};
-
-const enrichFeature = (
-  f: Feature<Geometry, GeoJsonProperties>,
-): Feature<Geometry, GeoJsonProperties>[] => {
-  if (f === undefined) {
-    return [];
-  }
-
-  const features: Feature<Geometry, GeoJsonProperties>[] = [];
-
-  // A single-coordinate LineString can arrive via import, and every path below reads at
-  // least two vertices.
-  if (f.geometry.type === "LineString" && f.geometry.coordinates.length >= 2) {
-    const enrich: EnrichLineConfig | undefined = EnrichLineStringMap[f.properties?.lineType];
-    if (enrich !== undefined) {
-      if (enrich.iconStart) {
-        const startPoint = point(f.geometry.coordinates[0]);
-        startPoint.id = `${f.id}:start`;
-        startPoint.properties = {
-          parent: f.id,
-          // Already a fully-namespaced sprite id; do not prefix again.
-          icon: enrich.iconStart,
-          iconRotation:
-            bearing(point(f.geometry.coordinates[0]), point(f.geometry.coordinates[1])) +
-            enrich.iconRotation,
-        };
-        features.push(startPoint);
-      }
-
-      if (enrich.iconEnd) {
-        const endPoint = point(f.geometry.coordinates.slice(-1)[0]);
-        endPoint.id = `${f.id}:end`;
-        endPoint.properties = {
-          parent: f.id,
-          icon: enrich.iconEnd,
-          iconRotation:
-            bearing(
-              f.geometry.coordinates.slice(-1)[0],
-              point(f.geometry.coordinates.slice(-2)[0]),
-            ) + enrich.iconRotation,
-        };
-        features.push(endPoint);
-      }
-
-      if (enrich.slideArrow) {
-        features.push(
-          ...buildSlideArrow(f.id, f.geometry.coordinates, enrich.slideArrow, f.properties?.color),
-        );
-      }
-    }
-  }
-
-  if (f.geometry.type === "Polygon" || f.geometry.type === "MultiPolygon") {
-    const flowArrow = EnrichPolygonMap[f.properties?.zoneType]?.flowArrow;
-    if (flowArrow !== undefined) {
-      // Outer rings only. A hole is interior detail, and an arrow springing off one would
-      // point into the zone rather than out of it.
-      const outerRings: Position[][] =
-        f.geometry.type === "Polygon"
-          ? [f.geometry.coordinates[0]]
-          : f.geometry.coordinates.map((part) => part[0]);
-
-      outerRings.forEach((ring, index) => {
-        if (ring === undefined) {
-          return;
-        }
-        features.push(
-          // A multipart zone gets one arrow per part, so the synthetic ids must stay distinct.
-          ...buildFlowArrow(
-            f.id,
-            outerRings.length > 1 ? `flow-${index}` : "flow",
-            ring,
-            flowArrow,
-            f.properties?.color,
-          ),
-        );
-      });
-    }
-  }
-
-  return features;
-};
-
-/**
- * A direction indicator built from the line's own shape rather than drawn at its ends —
- * see `buildSlideArrow` for how the side is chosen.
- */
-interface SlideArrowConfig {
-  /** Fully-namespaced chevron sprite for the arrow head. */
-  icon: string;
-  /** Shaft stroke colour, read back off `properties.color` by the enriched line layer. */
-  color: string;
-  /** Shaft length as a fraction of the parent line's length. */
-  lengthRatio: number;
+interface EnrichedFeaturesProps {
+  id: string | undefined;
+  featureCollection: FeatureCollection;
 }
 
-/**
- * A flow-direction arrow generated from a polygon's own outline.
- *
- * The polygon counterpart of `SlideArrowConfig`. Same fields, but `lengthRatio` is read
- * against a different measure — the ring's bounding-box diagonal rather than a line's
- * length — so they stay separate types rather than one whose ratio means two things.
- */
-interface FlowArrowConfig {
-  /** Fully-namespaced chevron sprite for the arrow head. */
-  icon: string;
-  /** Shaft stroke colour, read back off `properties.color` by the enriched line layer. */
-  color: string;
-  /** Shaft length as a fraction of the outer ring's bounding-box diagonal. */
-  lengthRatio: number;
-}
-
-interface EnrichPolygonConfig {
-  flowArrow?: FlowArrowConfig;
-}
-
-interface EnrichLineConfig {
-  /**
-   * Fully-namespaced sprite image id, e.g. `babs:1101` or `babs:marker-chevron-blue`.
-   *
-   * Unlike `properties.icon` on real features — which stores a readable alias and is
-   * resolved by the `match` expression in styleGenerator — these caps live on synthetic
-   * features that are rebuilt on every render and never persisted. So there is no
-   * data-compatibility concern and the sprite key can be used directly.
-   */
-  iconStart?: string;
-  iconEnd?: string;
-  iconRotation: number;
-  /**
-   * Perpendicular direction indicator derived from the geometry. Unlike the caps above
-   * this is not tied to an endpoint, so a line type may carry it with no cap at all.
-   */
-  slideArrow?: SlideArrowConfig;
-}
-
-/**
- * Direction arrowheads, from the catalogue's purpose-built markers. These previously
- * borrowed the `Others.Einsatz` / `Others.Verschiebung` glyphs from the bundled registry.
- *
- * The colour matches the stroke the line type is drawn in (see `LineTypes`), and the
- * single/double distinction is meaningful: *Einsatz* is a double chevron, *Verschiebung*
- * and reconnaissance a single one.
- */
-const ARROW = {
-  movement: babsImage(markerSpriteKey("chevron-blue")),
-  deployment: babsImage(markerSpriteKey("double-chevron-blue")),
-  fireSpread: babsImage(markerSpriteKey("chevron-red")),
-} as const;
-
-/**
- * Rotation added to a computed bearing to line the artwork up with it. The chevrons are
- * drawn pointing east, whereas a bearing is measured from north.
- */
-const CHEVRON_BEARING_OFFSET = 90;
-
-/** End-of-line arrowhead only — start is left bare so the line reads directionally. */
-const directional = (arrow: string = ARROW.movement): EnrichLineConfig => ({
-  iconStart: undefined,
-  iconEnd: arrow,
-  iconRotation: CHEVRON_BEARING_OFFSET,
-});
-
-/**
- * No cap at all: the whole indicator is the perpendicular slide arrow, drawn from the
- * boundary's midpoint towards the concave side.
- */
-const slideDirection = (): EnrichLineConfig => ({
-  iconRotation: CHEVRON_BEARING_OFFSET,
-  slideArrow: {
-    icon: ARROW.fireSpread,
-    color: Colors.Red,
-    lengthRatio: SLIDE_ARROW_LENGTH_RATIO,
-  },
-});
-
-/**
- * Damage severity marked at both ends of the affected road segment. These are semantic
- * symbols rather than arrowheads, so they stay catalogue icons rather than becoming
- * chevrons: 1101 Beschädigung, 1102 Teilzerstörung, 1103 Totalzerstörung.
- */
-const damageExtent = (id: "1101" | "1102" | "1103"): EnrichLineConfig => ({
-  iconStart: babsImage(id),
-  iconEnd: babsImage(id),
-  iconRotation: 90,
-});
-
-/**
- * Which line types get start/end caps, and which sprite image each cap uses.
- * Exported so `styleImageResolution.test.ts` can assert every cap actually exists in the
- * sprite atlas — these ids bypass the `match` expression, so nothing else would catch a
- * typo or an unprefixed key here.
- */
-export const EnrichLineStringMap: Record<string, EnrichLineConfig> = {
-  begehbar: damageExtent("1101"),
-  schwerBegehbar: damageExtent("1102"),
-  unpassierbar: damageExtent("1103"),
-  beabsichtigteErkundung: directional(),
-  durchgeführteErkundung: directional(),
-  beabsichtigteVerschiebung: directional(),
-  rettungsAchse: directional(),
-  durchgeführteVerschiebung: directional(),
-  // Einsatz takes the double chevron; it previously reused the single one, which made it
-  // indistinguishable from Verschiebung on the map.
-  beabsichtigterEinsatz: directional(ARROW.deployment),
-  durchgeführterEinsatz: directional(ARROW.deployment),
-  // Fire spread: the movement line styles in red, so a red chevron to match the stroke.
-  brandUebergriffGefahr: directional(ARROW.fireSpread),
-  brandUebergriffErfolgt: directional(ARROW.fireSpread),
-  // The only entry whose indicator is not a cap: the catalogue draws Rutschgebiet with a
-  // slide arrow across the boundary rather than a symbol at either end.
-  Rutschgebiet: slideDirection(),
-};
-
-/**
- * Which zone types get an indicator built from their geometry.
- *
- * Exported for the same reason as `EnrichLineStringMap`: these sprite ids are written
- * straight onto synthetic features and read by a bare `["get", "icon"]`, bypassing the
- * `match` expression, so only `styleImageResolution.test.ts` would catch a typo here.
- */
-export const EnrichPolygonMap: Record<string, EnrichPolygonConfig> = {
-  // 1115 is a flooded area *with a flow direction* — the arrow is part of the catalogue
-  // symbol rather than decoration, which is why it is generated rather than left to the user.
-  UeberschwemmtesGebiet: {
-    flowArrow: {
-      icon: ARROW.fireSpread,
-      color: Colors.Red,
-      lengthRatio: FLOW_ARROW_LENGTH_RATIO,
-    },
-  },
-};
-
-const EnrichedSymbolSource = (props: EnrichedFeaturesProps) => {
-  const { id, featureCollection } = props;
-  const enrichedFC: FeatureCollection = {
-    type: "FeatureCollection",
-    features: [],
-  };
-  // The selected feature is enriched too. It used to be skipped, which meant the indicator
-  // vanished for exactly as long as you were editing the geometry that determines it — and
-  // the flow arrow is aimed by dragging vertices, so that is when seeing it matters most.
-  // These are synthetic features in their own source, so they do not collide with the
-  // active-state styling mapbox-gl-draw puts on the feature itself.
-  //
-  // Memoised because on the active layer this now runs against a collection that changes on
-  // every animation frame of a vertex drag (see `useLiveDrawGeometry` in Map.tsx), rather
-  // than once per save.
-  enrichedFC.features = useMemo(
-    () =>
-      featureCollection.features
+const EnrichedSymbolSource = ({ id, featureCollection }: EnrichedFeaturesProps) => {
+  // Includes the selected feature. Skipping it used to make the indicator vanish for exactly
+  // as long as you were editing the geometry that determines it, which is when it is most
+  // useful — and on the active layer this now re-runs on every animation frame of a vertex
+  // drag (see `useLiveDrawGeometry` in Map.tsx) rather than once per save, hence the memo.
+  const enrichedFC = useMemo<FeatureCollection>(
+    () => ({
+      type: "FeatureCollection",
+      features: featureCollection.features
         .filter((f) => f.properties?.deletedAt === null)
-        .flatMap((f) => enrichFeature(f)),
+        .flatMap(enrichFeature),
+    }),
     [featureCollection],
   );
 
   return (
     <Source key={id} type="geojson" data={enrichedFC}>
       {/*
-        Slide-arrow shafts. Painted to match `gl-draw-line-inactive-solidlines` in
-        styleGenerator, so the shaft is the same stroke a brandUebergriffErfolgt line gets.
-        It has to be declared here rather than there: those layers bind to the draw and
-        display sources and never see this overlay. Declared before the symbol layer so the
-        chevron sits on top of its own shaft.
+        Shafts and emphasised outline. Painted to match `gl-draw-line-inactive-solidlines` in
+        styleGenerator, so a shaft is the same stroke a brandUebergriffErfolgt line gets.
+        Declared before the symbol layer so a chevron sits on top of its own shaft.
       */}
       <Layer
         id={`${id}-enriched-lines`}
@@ -638,10 +67,9 @@ const EnrichedSymbolSource = (props: EnrichedFeaturesProps) => {
         // symbol layer happily anchors a LineString.
         filter={["==", ["geometry-type"], "Point"]}
         layout={{
-          // ["image", …] is required for coalesce to fall through: a bare ["get", …]
-          // yields a non-null string even when the sprite has no such image, so the
-          // fallback was unreachable and an unknown cap rendered blank. The previous
-          // fallback, "default_marker", existed in no atlas either.
+          // ["image", …] is required for coalesce to fall through: a bare ["get", …] yields a
+          // non-null string even when the sprite has no such image, so the fallback was
+          // unreachable and an unknown cap rendered blank.
           "icon-image": ["coalesce", ["image", ["get", "icon"]], ["image", ARROW.movement]],
           "icon-allow-overlap": true,
           "icon-size": ["interpolate", ["linear"], ["zoom"], 12, 0.1, 17, 1.4],
@@ -662,12 +90,8 @@ const EnrichedFeaturesSource = (props: EnrichedFeaturesProps) => {
   return <EnrichedSymbolSource {...props} />;
 };
 
-interface EnrichedFeaturesProps {
-  id: string | undefined;
-  featureCollection: FeatureCollection;
-  selectedFeature?: string | number | undefined;
-}
-
-export { enrichFeature, EnrichedFeaturesSource, EnrichedSymbolSource };
+// Re-exported so callers and tests keep a single entry point into the enrichment pipeline.
+export { enrichFeature, EnrichLineStringMap, EnrichPolygonMap };
+export { EnrichedFeaturesSource, EnrichedSymbolSource };
 
 export default EnrichedFeaturesSource;

--- a/ui/src/components/map/EnrichedLayerFeatures.tsx
+++ b/ui/src/components/map/EnrichedLayerFeatures.tsx
@@ -1,4 +1,5 @@
 import along from "@turf/along";
+import bbox from "@turf/bbox";
 import bearing from "@turf/bearing";
 import destination from "@turf/destination";
 import distance from "@turf/distance";
@@ -58,6 +59,73 @@ const SLIDE_MIN_LINE_KM = 1e-6;
  * to that metre, which is the common case rendered invisible.
  */
 const SLIDE_SELF_CROSSING_RATIO = 0.1;
+/**
+ * Flow-arrow shaft length, as a fraction of the outer ring's bounding-box diagonal.
+ *
+ * Deliberately not the perimeter, which would be the obvious analogue of the slide arrow's
+ * `total`: perimeter grows with how finely the boundary was digitised, so a flood zone
+ * traced along a river with two hundred vertices would get an arrow several times the size
+ * of the zone it annotates. The diagonal tracks how large the zone actually looks.
+ */
+const FLOW_ARROW_LENGTH_RATIO = 0.12;
+/**
+ * Clamps on that fraction. Tighter than the slide arrow's: this one is a mark against one
+ * edge of an area rather than a span across a line, so it reads better short.
+ */
+const FLOW_ARROW_MIN_KM = 0.01;
+const FLOW_ARROW_MAX_KM = 0.17;
+/** Below this a ring is a stray click, with no extent to scale an arrow against. */
+const FLOW_MIN_EXTENT_KM = 1e-6;
+/**
+ * As `SLIDE_SELF_CROSSING_RATIO`, but load-bearing rather than defensive: the flow arrow's
+ * anchor *is* a ring vertex, so the ray leaves through the boundary by construction and
+ * would otherwise be truncated to nothing.
+ */
+const FLOW_SELF_CROSSING_RATIO = 0.1;
+/**
+ * Two positions this close are the same vertex. Rings close by repeating their first
+ * position, and finishing a polygon on top of an existing vertex leaves duplicates — both
+ * make the tangent bearing meaningless. 1e-9° is well under a millimetre.
+ */
+const VERTEX_EPSILON_DEG = 1e-9;
+
+/**
+ * The two features every generated arrow is made of: a shaft the enriched line layer
+ * strokes, and a chevron the enriched symbol layer places at its tip.
+ *
+ * Shared because the *contract* is shared — the `:kind` / `:kind-tip` id suffixes, `parent`,
+ * and above all the rotation convention below — not because the geometry is. Each builder
+ * still works out its own anchor, bearing and length; this only writes the result down.
+ */
+const arrowFeatures = (
+  parentId: Feature["id"],
+  /** Distinguishes this arrow's synthetic ids from any other the parent carries. */
+  kind: string,
+  tail: Position,
+  tip: Position,
+  /** Direction of travel, tail towards tip. */
+  aim: number,
+  icon: string,
+  color: string,
+): Feature<Geometry, GeoJsonProperties>[] => {
+  const shaft = lineString([tail, tip]);
+  shaft.id = `${parentId}:${kind}`;
+  shaft.properties = { parent: parentId, color };
+
+  const head = point(tip);
+  head.id = `${parentId}:${kind}-tip`;
+  head.properties = {
+    parent: parentId,
+    icon,
+    // Minus, not plus: the chevron artwork points east and `icon-rotate` is measured
+    // clockwise from north. The end caps reach the same place via `+ offset` only because
+    // they feed in a *reversed* bearing; this one is already a direction of travel, so
+    // adding would aim the head back up its own shaft.
+    iconRotation: aim - CHEVRON_BEARING_OFFSET,
+  };
+
+  return [shaft, head];
+};
 
 /**
  * The slide-direction arrow: a straight shaft leaving the boundary's midpoint at a right
@@ -130,23 +198,142 @@ const buildSlideArrow = (
   // Down the shaft, from the far end back to the boundary — the reverse of `slideBearing`.
   const aim = slideBearing + 180;
 
-  const shaft = lineString([tail.geometry.coordinates, tip.geometry.coordinates]);
-  shaft.id = `${parentId}:slide`;
-  shaft.properties = { parent: parentId, color: featureColor ?? config.color };
+  return arrowFeatures(
+    parentId,
+    "slide",
+    tail.geometry.coordinates,
+    tip.geometry.coordinates,
+    aim,
+    config.icon,
+    featureColor ?? config.color,
+  );
+};
 
-  const head = point(tip.geometry.coordinates);
-  head.id = `${parentId}:slide-tip`;
-  head.properties = {
-    parent: parentId,
-    icon: config.icon,
-    // Minus, not plus: the chevron artwork points east and `icon-rotate` is measured
-    // clockwise from north. The end caps reach the same place via `+ offset` only because
-    // they feed in a *reversed* bearing; this one is already a direction of travel, so
-    // adding would aim the head back up its own shaft.
-    iconRotation: aim - CHEVRON_BEARING_OFFSET,
-  };
+const samePosition = (a: Position, b: Position): boolean =>
+  Math.abs(a[0] - b[0]) < VERTEX_EPSILON_DEG && Math.abs(a[1] - b[1]) < VERTEX_EPSILON_DEG;
 
-  return [shaft, head];
+/**
+ * The ring with its closing repeat removed, so the last entry is the last vertex the user
+ * actually placed rather than a copy of the first.
+ *
+ * Pops in a loop rather than dropping a single position: finishing a polygon on top of the
+ * first vertex can leave more than one copy, and an import may repeat it too.
+ */
+const openRing = (ring: Position[]): Position[] => {
+  const open = ring.slice();
+  while (open.length > 1 && samePosition(open[open.length - 1], open[0])) {
+    open.pop();
+  }
+  return open;
+};
+
+/**
+ * Twice the signed area of a ring, by the shoelace formula. Positive means the ring is
+ * wound counter-clockwise, negative clockwise.
+ *
+ * Only the sign is used, so working in raw degrees is fine — no projection needed. This is
+ * what tells the arrow which perpendicular points out of the zone rather than into it: on a
+ * counter-clockwise ring the interior lies to the left of travel, so outward is the right.
+ */
+const ringWinding = (ring: Position[]): number => {
+  let doubleArea = 0;
+  for (let i = 0; i < ring.length; i += 1) {
+    const [x1, y1] = ring[i];
+    const [x2, y2] = ring[(i + 1) % ring.length];
+    doubleArea += x1 * y2 - x2 * y1;
+  }
+  return doubleArea;
+};
+
+/**
+ * The flow-direction arrow: a straight shaft springing from the last vertex of the outer
+ * ring, leaving it at a right angle to the last segment drawn, tipped with a chevron.
+ *
+ * Direction comes from where the user stopped drawing — an input they already control — so
+ * nothing extra has to be persisted. Unlike the slide arrow the tail sits *on* the boundary:
+ * a polygon stroke is 2px, so there is no pattern band to clear, and springing from the
+ * outline is what makes the arrow read as belonging to it.
+ */
+const buildFlowArrow = (
+  parentId: Feature["id"],
+  kind: string,
+  ring: Position[],
+  config: FlowArrowConfig,
+  /** The feature's own stroke colour, so a recoloured zone keeps its arrow in step. */
+  featureColor: string | undefined,
+): Feature<Geometry, GeoJsonProperties>[] => {
+  const open = openRing(ring);
+  // Fewer than three distinct vertices enclose nothing, so there is no inside for the arrow
+  // to point out of.
+  if (open.length < 3) {
+    return [];
+  }
+
+  const anchor = open[open.length - 1];
+  // Walk back past any repeated vertex: `bearing` between two identical positions is 0, not
+  // NaN, so without this every such arrow would quietly point due north instead of failing.
+  let prior = open.length - 2;
+  while (prior >= 0 && samePosition(open[prior], anchor)) {
+    prior -= 1;
+  }
+  if (prior < 0) {
+    return [];
+  }
+
+  // At a right angle to the last segment, on whichever side lies outside the ring. Taken
+  // from the winding rather than probed with a containment test, which would be ambiguous
+  // here: the anchor is a corner, so a point offset from it can fall either side depending
+  // on how sharp the corner is.
+  const alongLastSegment = bearing(point(open[prior]), point(anchor));
+  const flowBearing = alongLastSegment + (ringWinding(open) > 0 ? 90 : -90);
+
+  // Springs from the middle of the last segment rather than from its end vertex. A corner is
+  // shared by two edges, so an arrow planted there reads as belonging to neither; the middle
+  // of an edge is unambiguous, and the perpendicular genuinely separates inside from out.
+  const segment = distance(point(open[prior]), point(anchor), { units: "kilometers" });
+  const base = destination(point(open[prior]), segment / 2, alongLastSegment, {
+    units: "kilometers",
+  });
+  const tail = base.geometry.coordinates;
+
+  // Measured against the *closed* ring: the segment from the last vertex back to the first
+  // is real boundary, and on a convex zone it is the one the arrow is likeliest to meet.
+  const boundary = lineString([...open, open[0]]);
+  const [minX, minY, maxX, maxY] = bbox(boundary);
+  const extent = distance(point([minX, minY]), point([maxX, maxY]), { units: "kilometers" });
+  // Negated so a NaN extent is rejected too.
+  if (!(extent > FLOW_MIN_EXTENT_KM)) {
+    return [];
+  }
+
+  // Never longer than the zone it annotates, so a hand-drawn stub gets a stub.
+  const nominal = Math.min(
+    Math.max(extent * config.lengthRatio, Math.min(FLOW_ARROW_MIN_KM, extent)),
+    FLOW_ARROW_MAX_KM,
+  );
+
+  // The outward normal is not guaranteed to stay outside — on a concave ring it can re-enter.
+  // The bearing is honoured either way, since it follows from the boundary the user drew, but
+  // the ray stops at the first crossing so a wrong-way arrow stays a local mark rather than
+  // spearing the whole zone.
+  const reach = destination(base, nominal, flowBearing, { units: "kilometers" });
+  const crossings = lineIntersect(lineString([tail, reach.geometry.coordinates]), boundary)
+    .features.map((crossing) => distance(base, crossing, { units: "kilometers" }))
+    // The tail sits on the boundary, so the ray leaves through it; ignore that crossing.
+    .filter((km) => km > nominal * FLOW_SELF_CROSSING_RATIO);
+  const span = crossings.length > 0 ? Math.min(nominal, ...crossings) : nominal;
+
+  const tip = destination(base, span, flowBearing, { units: "kilometers" });
+
+  return arrowFeatures(
+    parentId,
+    kind,
+    tail,
+    tip.geometry.coordinates,
+    flowBearing,
+    config.icon,
+    featureColor ?? config.color,
+  );
 };
 
 const enrichFeature = (
@@ -200,6 +387,34 @@ const enrichFeature = (
     }
   }
 
+  if (f.geometry.type === "Polygon" || f.geometry.type === "MultiPolygon") {
+    const flowArrow = EnrichPolygonMap[f.properties?.zoneType]?.flowArrow;
+    if (flowArrow !== undefined) {
+      // Outer rings only. A hole is interior detail, and an arrow springing off one would
+      // point into the zone rather than out of it.
+      const outerRings: Position[][] =
+        f.geometry.type === "Polygon"
+          ? [f.geometry.coordinates[0]]
+          : f.geometry.coordinates.map((part) => part[0]);
+
+      outerRings.forEach((ring, index) => {
+        if (ring === undefined) {
+          return;
+        }
+        features.push(
+          // A multipart zone gets one arrow per part, so the synthetic ids must stay distinct.
+          ...buildFlowArrow(
+            f.id,
+            outerRings.length > 1 ? `flow-${index}` : "flow",
+            ring,
+            flowArrow,
+            f.properties?.color,
+          ),
+        );
+      });
+    }
+  }
+
   return features;
 };
 
@@ -214,6 +429,26 @@ interface SlideArrowConfig {
   color: string;
   /** Shaft length as a fraction of the parent line's length. */
   lengthRatio: number;
+}
+
+/**
+ * A flow-direction arrow generated from a polygon's own outline.
+ *
+ * The polygon counterpart of `SlideArrowConfig`. Same fields, but `lengthRatio` is read
+ * against a different measure — the ring's bounding-box diagonal rather than a line's
+ * length — so they stay separate types rather than one whose ratio means two things.
+ */
+interface FlowArrowConfig {
+  /** Fully-namespaced chevron sprite for the arrow head. */
+  icon: string;
+  /** Shaft stroke colour, read back off `properties.color` by the enriched line layer. */
+  color: string;
+  /** Shaft length as a fraction of the outer ring's bounding-box diagonal. */
+  lengthRatio: number;
+}
+
+interface EnrichPolygonConfig {
+  flowArrow?: FlowArrowConfig;
 }
 
 interface EnrichLineConfig {
@@ -311,6 +546,25 @@ export const EnrichLineStringMap: Record<string, EnrichLineConfig> = {
   // The only entry whose indicator is not a cap: the catalogue draws Rutschgebiet with a
   // slide arrow across the boundary rather than a symbol at either end.
   Rutschgebiet: slideDirection(),
+};
+
+/**
+ * Which zone types get an indicator built from their geometry.
+ *
+ * Exported for the same reason as `EnrichLineStringMap`: these sprite ids are written
+ * straight onto synthetic features and read by a bare `["get", "icon"]`, bypassing the
+ * `match` expression, so only `styleImageResolution.test.ts` would catch a typo here.
+ */
+export const EnrichPolygonMap: Record<string, EnrichPolygonConfig> = {
+  // 1115 is a flooded area *with a flow direction* — the arrow is part of the catalogue
+  // symbol rather than decoration, which is why it is generated rather than left to the user.
+  UeberschwemmtesGebiet: {
+    flowArrow: {
+      icon: ARROW.fireSpread,
+      color: Colors.Red,
+      lengthRatio: FLOW_ARROW_LENGTH_RATIO,
+    },
+  },
 };
 
 const EnrichedSymbolSource = (props: EnrichedFeaturesProps) => {

--- a/ui/src/components/map/enrichment/arrow.ts
+++ b/ui/src/components/map/enrichment/arrow.ts
@@ -1,0 +1,113 @@
+import destination from "@turf/destination";
+import distance from "@turf/distance";
+import { lineString, point } from "@turf/helpers";
+import lineIntersect from "@turf/line-intersect";
+import { markerSpriteKey } from "@f-eld-ch/babs-core";
+import { babsImage } from "components/babs/iconResolver";
+import type { Feature, LineString, Point, Position } from "geojson";
+import type { ArrowConfig, SyntheticFeature } from "./types";
+
+/**
+ * The pieces every generated arrow is built from, shared by the slide and flow arrows.
+ *
+ * What they have in common is the *contract*, not the geometry: the id suffixes, the
+ * `parent` back-reference, the rotation convention, and how a length is bounded. Each
+ * builder still works out its own anchor, bearing and extent.
+ */
+
+/** Every measurement in this pipeline is in kilometres. */
+export const KM = { units: "kilometers" } as const;
+
+/**
+ * Direction arrowheads, from the catalogue's purpose-built markers.
+ *
+ * The colour matches the stroke the line type is drawn in (see `LineTypes`), and the
+ * single/double distinction is meaningful: *Einsatz* is a double chevron, *Verschiebung* and
+ * reconnaissance a single one.
+ */
+export const ARROW = {
+  movement: babsImage(markerSpriteKey("chevron-blue")),
+  deployment: babsImage(markerSpriteKey("double-chevron-blue")),
+  fireSpread: babsImage(markerSpriteKey("chevron-red")),
+} as const;
+
+/**
+ * Rotation added to a computed bearing to line the artwork up with it. The chevrons are
+ * drawn pointing east, whereas a bearing is measured from north.
+ */
+export const CHEVRON_BEARING_OFFSET = 90;
+
+/**
+ * A shaft the enriched line layer strokes, and a chevron the enriched symbol layer places at
+ * its tip.
+ */
+export const arrowFeatures = (
+  parentId: Feature["id"],
+  /** Distinguishes this arrow's synthetic ids from any other the parent carries. */
+  kind: string,
+  tail: Position,
+  tip: Position,
+  /** Direction of travel, tail towards tip. */
+  aim: number,
+  icon: string,
+  color: string,
+): SyntheticFeature[] => {
+  const shaft = lineString([tail, tip]);
+  shaft.id = `${parentId}:${kind}`;
+  shaft.properties = { parent: parentId, color };
+
+  const head = point(tip);
+  head.id = `${parentId}:${kind}-tip`;
+  head.properties = {
+    parent: parentId,
+    icon,
+    // Minus, not plus: the chevron artwork points east and `icon-rotate` is measured
+    // clockwise from north. The end caps reach the same place via `+ offset` only because
+    // they feed in a *reversed* bearing; this one is already a direction of travel, so
+    // adding would aim the head back up its own shaft.
+    iconRotation: aim - CHEVRON_BEARING_OFFSET,
+  };
+
+  return [shaft, head];
+};
+
+/**
+ * An arrow length proportional to the feature it annotates, bounded at both ends.
+ *
+ * The lower bound is itself capped at `extent`, so a stray short feature gets a stub rather
+ * than a spike several times its own size.
+ */
+export const clampArrowLength = (
+  extent: number,
+  config: ArrowConfig,
+  min: number,
+  max: number,
+): number => Math.min(Math.max(extent * config.lengthRatio, Math.min(min, extent)), max);
+
+/**
+ * How far a ray of `nominal` km can run from `base` on `aim` before it meets `boundary`
+ * again — so an arrow stops at the far wall of a bend instead of spearing across it.
+ *
+ * `base` sits on the boundary in both callers, so the ray departs through it immediately.
+ * Crossings nearer than `selfCrossingRatio` of the nominal length are that departure rather
+ * than a genuine far side, and are discounted. That threshold is a fraction rather than an
+ * exact zero because the two are not always coincident: a midpoint found along a great
+ * circle sits a little off a boundary drawn as a planar chord.
+ */
+export const spanBeforeCrossing = (
+  base: Feature<Point>,
+  aim: number,
+  nominal: number,
+  boundary: Feature<LineString>,
+  selfCrossingRatio: number,
+): number => {
+  const reach = destination(base, nominal, aim, KM);
+  const crossings = lineIntersect(
+    lineString([base.geometry.coordinates, reach.geometry.coordinates]),
+    boundary,
+  )
+    .features.map((crossing) => distance(base, crossing, KM))
+    .filter((km) => km > nominal * selfCrossingRatio);
+
+  return crossings.length > 0 ? Math.min(nominal, ...crossings) : nominal;
+};

--- a/ui/src/components/map/enrichment/enrichFeature.ts
+++ b/ui/src/components/map/enrichment/enrichFeature.ts
@@ -1,0 +1,112 @@
+import bearing from "@turf/bearing";
+import { point } from "@turf/helpers";
+import type { Feature, Position } from "geojson";
+import { buildFlowArrow } from "./flowArrow";
+import { EnrichLineStringMap, EnrichPolygonMap } from "./registry";
+import { buildSlideArrow } from "./slideArrow";
+import type { SyntheticFeature } from "./types";
+
+/**
+ * A cap at one end of a line.
+ *
+ * Rotated to the bearing from that end *towards its neighbour* — inwards, at both ends —
+ * which is why the configured offset is added here where the arrow builders subtract it.
+ */
+const capFeature = (
+  parentId: Feature["id"],
+  kind: "start" | "end",
+  at: Position,
+  towards: Position,
+  icon: string,
+  iconRotation: number,
+): SyntheticFeature => {
+  const cap = point(at);
+  cap.id = `${parentId}:${kind}`;
+  cap.properties = {
+    parent: parentId,
+    // Already a fully-namespaced sprite id; do not prefix again.
+    icon,
+    iconRotation: bearing(point(at), point(towards)) + iconRotation,
+  };
+  return cap;
+};
+
+/**
+ * The extra features a stored feature is drawn with, derived from its own geometry.
+ *
+ * Returns only the synthetic additions — never the feature itself, which the draw and display
+ * sources render. An unregistered line or zone type yields nothing.
+ */
+export const enrichFeature = (f: SyntheticFeature): SyntheticFeature[] => {
+  if (f === undefined) {
+    return [];
+  }
+
+  const features: SyntheticFeature[] = [];
+
+  // A single-coordinate LineString can arrive via import, and every path below reads at least
+  // two vertices.
+  if (f.geometry.type === "LineString" && f.geometry.coordinates.length >= 2) {
+    const enrich = EnrichLineStringMap[f.properties?.lineType];
+    const coordinates = f.geometry.coordinates;
+    const last = coordinates.length - 1;
+
+    if (enrich?.iconStart) {
+      features.push(
+        capFeature(
+          f.id,
+          "start",
+          coordinates[0],
+          coordinates[1],
+          enrich.iconStart,
+          enrich.iconRotation,
+        ),
+      );
+    }
+    if (enrich?.iconEnd) {
+      features.push(
+        capFeature(
+          f.id,
+          "end",
+          coordinates[last],
+          coordinates[last - 1],
+          enrich.iconEnd,
+          enrich.iconRotation,
+        ),
+      );
+    }
+    if (enrich?.slideArrow) {
+      features.push(...buildSlideArrow(f.id, coordinates, enrich.slideArrow, f.properties?.color));
+    }
+  }
+
+  if (f.geometry.type === "Polygon" || f.geometry.type === "MultiPolygon") {
+    const flowArrow = EnrichPolygonMap[f.properties?.zoneType]?.flowArrow;
+    if (flowArrow !== undefined) {
+      // Outer rings only. A hole is interior detail, and an arrow springing off one would
+      // point into the zone rather than out of it.
+      const outerRings: Position[][] =
+        f.geometry.type === "Polygon"
+          ? [f.geometry.coordinates[0]]
+          : f.geometry.coordinates.map((part) => part[0]);
+
+      outerRings.forEach((ring, index) => {
+        if (ring === undefined) {
+          return;
+        }
+        features.push(
+          // A multipart zone gets one arrow per part, so the synthetic ids must stay distinct.
+          ...buildFlowArrow(
+            f.id,
+            outerRings.length > 1 ? `flow-${index}` : "flow",
+            ring,
+            flowArrow,
+            f.properties?.color,
+          ),
+        );
+      });
+    }
+  }
+
+  return features;
+};

--- a/ui/src/components/map/enrichment/flowArrow.ts
+++ b/ui/src/components/map/enrichment/flowArrow.ts
@@ -1,0 +1,162 @@
+import bbox from "@turf/bbox";
+import bearing from "@turf/bearing";
+import destination from "@turf/destination";
+import distance from "@turf/distance";
+import { lineString, point } from "@turf/helpers";
+import type { Feature, Position } from "geojson";
+import { arrowFeatures, clampArrowLength, KM, spanBeforeCrossing } from "./arrow";
+import type { ArrowConfig, SyntheticFeature } from "./types";
+
+/**
+ * Shaft length as a fraction of the outer ring's bounding-box diagonal.
+ *
+ * Deliberately not the perimeter, which would be the obvious analogue of the slide arrow's
+ * line length: perimeter grows with how finely the boundary was digitised, so a flood zone
+ * traced along a river with two hundred vertices would get an arrow several times the size of
+ * the zone it annotates. The diagonal tracks how large the zone actually looks.
+ */
+export const FLOW_ARROW_LENGTH_RATIO = 0.12;
+/**
+ * Clamps on that fraction. Tighter than the slide arrow's: this one is a mark against one
+ * edge of an area rather than a span across a line, so it reads better short.
+ */
+const FLOW_ARROW_MIN_KM = 0.01;
+const FLOW_ARROW_MAX_KM = 0.17;
+/** Below this a ring is a stray click, with no extent to scale an arrow against. */
+const FLOW_MIN_EXTENT_KM = 1e-6;
+/**
+ * Stroke width for the stretch of outline the arrow springs from, against the 2px every other
+ * line is drawn at.
+ *
+ * This is the thickened-outline half of the catalogue's 1115, and it doubles as the answer to
+ * "which edge is the arrow attached to" while the zone is being edited — mapbox-gl-draw tags
+ * vertices with a `coord_path` whose last index depends on the vertex count, so the closing
+ * edge's endpoints cannot be picked out by a style filter.
+ */
+const FLOW_EDGE_WIDTH = 4;
+/** See `spanBeforeCrossing`. Load-bearing here: the tail is *on* the ring by construction. */
+const FLOW_SELF_CROSSING_RATIO = 0.1;
+/**
+ * Two positions this close are the same vertex. Rings close by repeating their first position,
+ * and finishing a polygon on top of an existing vertex leaves duplicates. 1e-9° is well under
+ * a millimetre.
+ */
+const VERTEX_EPSILON_DEG = 1e-9;
+
+const samePosition = (a: Position, b: Position): boolean =>
+  Math.abs(a[0] - b[0]) < VERTEX_EPSILON_DEG && Math.abs(a[1] - b[1]) < VERTEX_EPSILON_DEG;
+
+/**
+ * The ring with its closing repeat removed, so the last entry is the last vertex the user
+ * actually placed rather than a copy of the first.
+ *
+ * Pops in a loop rather than dropping a single position: finishing a polygon on top of the
+ * first vertex can leave more than one copy, and an import may repeat it too.
+ */
+const openRing = (ring: Position[]): Position[] => {
+  const open = ring.slice();
+  while (open.length > 1 && samePosition(open[open.length - 1], open[0])) {
+    open.pop();
+  }
+  return open;
+};
+
+/**
+ * Twice the signed area of a ring, by the shoelace formula. Positive means the ring is wound
+ * counter-clockwise, negative clockwise.
+ *
+ * Only the sign is used, so working in raw degrees is fine — no projection needed. This is
+ * what tells the arrow which perpendicular points out of the zone rather than into it: on a
+ * counter-clockwise ring the interior lies to the left of travel, so outward is the right.
+ */
+const ringWinding = (ring: Position[]): number => {
+  let doubleArea = 0;
+  for (let i = 0; i < ring.length; i += 1) {
+    const [x1, y1] = ring[i];
+    const [x2, y2] = ring[(i + 1) % ring.length];
+    doubleArea += x1 * y2 - x2 * y1;
+  }
+  return doubleArea;
+};
+
+/**
+ * The flow-direction arrow: a straight shaft springing from the middle of the outer ring's
+ * closing edge, leaving it at a right angle, tipped with a chevron — plus that edge redrawn
+ * heavier.
+ *
+ * The closing edge — last vertex back to the first — is the one the user never clicks: it
+ * appears when the ring closes. That makes it the easiest to predict while drawing and the
+ * easiest to aim afterwards, since moving either of its two endpoints swings the arrow.
+ * Nothing extra has to be persisted as a result.
+ *
+ * Unlike the slide arrow the tail sits *on* the boundary: a polygon stroke is 2px, so there is
+ * no pattern band to clear, and springing from the outline is what makes the arrow read as
+ * belonging to it.
+ */
+export const buildFlowArrow = (
+  parentId: Feature["id"],
+  kind: string,
+  ring: Position[],
+  config: ArrowConfig,
+  /** The feature's own stroke colour, so a recoloured zone keeps its arrow in step. */
+  featureColor: string | undefined,
+): SyntheticFeature[] => {
+  const open = openRing(ring);
+  // Fewer than three distinct vertices enclose nothing, so there is no inside to point out of.
+  if (open.length < 3) {
+    return [];
+  }
+
+  // The closing edge. `openRing` guarantees its two ends differ, so it always has a direction.
+  const from = open[open.length - 1];
+  const to = open[0];
+  const alongClosingEdge = bearing(point(from), point(to));
+
+  // At a right angle to that edge, on whichever side lies outside the ring. The side comes
+  // from the winding rather than from a containment probe: only the sign of the signed area is
+  // needed, which is exact, where a probe offset from the boundary can land either side.
+  const flowBearing = alongClosingEdge + (ringWinding(open) > 0 ? 90 : -90);
+
+  // Springs from the middle of the edge rather than from a vertex. A corner is shared by two
+  // edges, so an arrow planted there reads as belonging to neither, and the perpendicular at a
+  // corner does not cleanly separate inside from out.
+  const segment = distance(point(from), point(to), KM);
+  const base = destination(point(from), segment / 2, alongClosingEdge, KM);
+
+  // Measured against the *closed* ring: the closing edge is real boundary, and on a convex
+  // zone it is the one the arrow is likeliest to meet.
+  const boundary = lineString([...open, open[0]]);
+  const [minX, minY, maxX, maxY] = bbox(boundary);
+  const extent = distance(point([minX, minY]), point([maxX, maxY]), KM);
+  // Negated so a NaN extent is rejected too.
+  if (!(extent > FLOW_MIN_EXTENT_KM)) {
+    return [];
+  }
+
+  const nominal = clampArrowLength(extent, config, FLOW_ARROW_MIN_KM, FLOW_ARROW_MAX_KM);
+  // The outward normal is not guaranteed to stay outside — on a concave ring it can re-enter.
+  // The bearing is honoured either way, since it follows from the boundary the user drew, but
+  // stopping at the first crossing keeps a wrong-way arrow a local mark rather than a spear.
+  const span = spanBeforeCrossing(base, flowBearing, nominal, boundary, FLOW_SELF_CROSSING_RATIO);
+  const tip = destination(base, span, flowBearing, KM);
+  const color = featureColor ?? config.color;
+
+  // The closing edge itself, redrawn heavier. Emitted before the shaft so the shaft paints over
+  // the join rather than being cut by it.
+  const edge = lineString([from, to]);
+  edge.id = `${parentId}:${kind}-edge`;
+  edge.properties = { parent: parentId, color, width: FLOW_EDGE_WIDTH };
+
+  return [
+    edge,
+    ...arrowFeatures(
+      parentId,
+      kind,
+      base.geometry.coordinates,
+      tip.geometry.coordinates,
+      flowBearing,
+      config.icon,
+      color,
+    ),
+  ];
+};

--- a/ui/src/components/map/enrichment/registry.ts
+++ b/ui/src/components/map/enrichment/registry.ts
@@ -1,0 +1,80 @@
+import { babsImage } from "components/babs/iconResolver";
+import { Colors } from "components/babs/lineAndZoneTypes";
+import { ARROW, CHEVRON_BEARING_OFFSET } from "./arrow";
+import { FLOW_ARROW_LENGTH_RATIO } from "./flowArrow";
+import { SLIDE_ARROW_LENGTH_RATIO } from "./slideArrow";
+import type { EnrichLineConfig, EnrichPolygonConfig } from "./types";
+
+/**
+ * Which line and zone types get a generated indicator, and what each one looks like.
+ *
+ * Both maps are exported so `styleImageResolution.test.ts` can assert every sprite named here
+ * exists in the atlas: these ids are written straight onto synthetic features and read by a
+ * bare `["get", "icon"]`, bypassing the `match` expression, so nothing else would catch a typo
+ * or an unprefixed key.
+ */
+
+/** End-of-line arrowhead only — start is left bare so the line reads directionally. */
+const directional = (arrow: string = ARROW.movement): EnrichLineConfig => ({
+  iconStart: undefined,
+  iconEnd: arrow,
+  iconRotation: CHEVRON_BEARING_OFFSET,
+});
+
+/**
+ * Damage severity marked at both ends of the affected road segment. These are semantic symbols
+ * rather than arrowheads, so they stay catalogue icons rather than becoming chevrons: 1101
+ * Beschädigung, 1102 Teilzerstörung, 1103 Totalzerstörung.
+ */
+const damageExtent = (id: "1101" | "1102" | "1103"): EnrichLineConfig => ({
+  iconStart: babsImage(id),
+  iconEnd: babsImage(id),
+  iconRotation: CHEVRON_BEARING_OFFSET,
+});
+
+/**
+ * No cap at all: the whole indicator is the slide arrow, drawn across the boundary. Its ratio
+ * is read against the line's own length.
+ */
+const slideDirection = (): EnrichLineConfig => ({
+  iconRotation: CHEVRON_BEARING_OFFSET,
+  slideArrow: {
+    icon: ARROW.fireSpread,
+    color: Colors.Red,
+    lengthRatio: SLIDE_ARROW_LENGTH_RATIO,
+  },
+});
+
+export const EnrichLineStringMap: Record<string, EnrichLineConfig> = {
+  begehbar: damageExtent("1101"),
+  schwerBegehbar: damageExtent("1102"),
+  unpassierbar: damageExtent("1103"),
+  beabsichtigteErkundung: directional(),
+  durchgeführteErkundung: directional(),
+  beabsichtigteVerschiebung: directional(),
+  rettungsAchse: directional(),
+  durchgeführteVerschiebung: directional(),
+  // Einsatz takes the double chevron; it previously reused the single one, which made it
+  // indistinguishable from Verschiebung on the map.
+  beabsichtigterEinsatz: directional(ARROW.deployment),
+  durchgeführterEinsatz: directional(ARROW.deployment),
+  // Fire spread: the movement line styles in red, so a red chevron to match the stroke.
+  brandUebergriffGefahr: directional(ARROW.fireSpread),
+  brandUebergriffErfolgt: directional(ARROW.fireSpread),
+  // The only entry whose indicator is not a cap: the catalogue draws Rutschgebiet with a slide
+  // arrow across the boundary rather than a symbol at either end.
+  Rutschgebiet: slideDirection(),
+};
+
+export const EnrichPolygonMap: Record<string, EnrichPolygonConfig> = {
+  // 1115 is a flooded area *with a flow direction* — the arrow is part of the catalogue symbol
+  // rather than decoration, which is why it is generated rather than left to the user. Its
+  // ratio is read against the ring's bounding-box diagonal.
+  UeberschwemmtesGebiet: {
+    flowArrow: {
+      icon: ARROW.fireSpread,
+      color: Colors.Red,
+      lengthRatio: FLOW_ARROW_LENGTH_RATIO,
+    },
+  },
+};

--- a/ui/src/components/map/enrichment/slideArrow.ts
+++ b/ui/src/components/map/enrichment/slideArrow.ts
@@ -1,0 +1,108 @@
+import along from "@turf/along";
+import bearing from "@turf/bearing";
+import destination from "@turf/destination";
+import { lineString } from "@turf/helpers";
+import turfLength from "@turf/length";
+import type { Feature, Position } from "geojson";
+import { arrowFeatures, clampArrowLength, KM, spanBeforeCrossing } from "./arrow";
+import type { ArrowConfig, SyntheticFeature } from "./types";
+
+/** Shaft length as a fraction of the parent line's length. */
+export const SLIDE_ARROW_LENGTH_RATIO = 0.25;
+/** Clamps on that fraction, so a hand-drawn stub still shows and a long boundary stays readable. */
+const SLIDE_ARROW_MIN_KM = 0.025;
+const SLIDE_ARROW_MAX_KM = 0.5;
+/**
+ * How far either side of the midpoint the local bearing is measured, as a fraction of the
+ * line's length. Taken across a span rather than between the two vertices flanking the
+ * midpoint so a kink landing exactly there does not swing the arrow off the perpendicular.
+ */
+const SLIDE_BEARING_SPAN = 0.05;
+/**
+ * Which perpendicular the arrow occupies, as a signed multiple of 90° on the local bearing:
+ * -1 is the left of travel, +1 the right.
+ *
+ * Fixed to the draw direction, not derived from the shape. maplibre's line bucket extrudes
+ * its `up = false` half-vertex along `perp(direction)`, and the line-pattern fragment shader
+ * maps that vertex to texture y = 0 — the top row of the tile. Tile space is y-down, so for
+ * an eastward line that is south: the top of a pattern tile always lands on the right of
+ * travel. The `1113-pattern` tile carries its teeth in those top rows, so the teeth fall on
+ * the right of travel, and the arrow shares that side — set by eye against the rendered
+ * symbol, so flip this one constant if it ever needs to go the other way.
+ *
+ * Tying the arrow to draw direction rather than to curvature is what makes reversing a
+ * linestring mirror the whole symbol at once, teeth and arrow together — which is how the
+ * mirrored line type came to be retired.
+ */
+const SLIDE_ARROW_SIDE = 1;
+/**
+ * Clear space left between the boundary and each end of the arrow, as a fraction of the span
+ * available to it. The arrow annotates the boundary rather than touching it, and the pattern
+ * band it sits against is drawn up to 22px wide, so a shaft flush with the line disappears
+ * into it.
+ */
+const SLIDE_ARROW_GAP_RATIO = 0.12;
+/** Below this a line is a stray click, not a boundary: `along` degenerates and the bearing is noise. */
+const SLIDE_MIN_LINE_KM = 1e-6;
+/** See `spanBeforeCrossing`. */
+const SLIDE_SELF_CROSSING_RATIO = 0.1;
+
+/**
+ * The slide-direction arrow: a straight shaft leaving the boundary's midpoint at a right
+ * angle, tipped with a chevron.
+ *
+ * It sits on the side the pattern's teeth do not occupy (see `SLIDE_ARROW_SIDE`) and points
+ * *back at* the boundary: the slide runs onto the line, so the head is the end nearest it.
+ * Neither end touches — a shaft flush with the line vanishes into a pattern band drawn up to
+ * 22px wide.
+ */
+export const buildSlideArrow = (
+  parentId: Feature["id"],
+  coordinates: Position[],
+  config: ArrowConfig,
+  /** The feature's own stroke colour, so a recoloured boundary keeps its arrow in step. */
+  featureColor: string | undefined,
+): SyntheticFeature[] => {
+  if (coordinates.length < 2) {
+    return [];
+  }
+
+  const line = lineString(coordinates);
+  const total = turfLength(line, KM);
+  // Negated so a NaN length is rejected too. Below the floor every vertex effectively
+  // coincides and there is no direction to be perpendicular to.
+  if (!(total > SLIDE_MIN_LINE_KM)) {
+    return [];
+  }
+
+  const half = total / 2;
+  const base = along(line, half, KM);
+  const before = along(line, Math.max(half - total * SLIDE_BEARING_SPAN, 0), KM);
+  const after = along(line, Math.min(half + total * SLIDE_BEARING_SPAN, total), KM);
+
+  // Away from the boundary, on the side the teeth do not occupy. The arrow is then built
+  // back along this bearing, so it approaches the line rather than springing off it.
+  const slideBearing = bearing(before, after) + SLIDE_ARROW_SIDE * 90;
+
+  const nominal = clampArrowLength(total, config, SLIDE_ARROW_MIN_KM, SLIDE_ARROW_MAX_KM);
+  // A boundary that curves back on itself — the usual shape — would otherwise have the arrow
+  // run across the bowl and bury its head in the pattern band on the far side.
+  const span = spanBeforeCrossing(base, slideBearing, nominal, line, SLIDE_SELF_CROSSING_RATIO);
+
+  // Both ends are held off: the head stops short of the line rather than touching it, and the
+  // tail stops short of whatever the probe found on the far side.
+  const gap = span * SLIDE_ARROW_GAP_RATIO;
+  const tip = destination(base, gap, slideBearing, KM);
+  const tail = destination(base, span - gap, slideBearing, KM);
+
+  return arrowFeatures(
+    parentId,
+    "slide",
+    tail.geometry.coordinates,
+    tip.geometry.coordinates,
+    // Down the shaft, from the far end back to the boundary — the reverse of `slideBearing`.
+    slideBearing + 180,
+    config.icon,
+    featureColor ?? config.color,
+  );
+};

--- a/ui/src/components/map/enrichment/types.ts
+++ b/ui/src/components/map/enrichment/types.ts
@@ -1,0 +1,63 @@
+import type { Feature, GeoJsonProperties, Geometry } from "geojson";
+
+/**
+ * Shapes shared by the enrichment pipeline: what a feature can be decorated with, and what
+ * the builders hand back.
+ *
+ * Enrichment turns a stored feature into extra, throwaway features that carry the parts of a
+ * BABS symbol the catalogue defines but GeoJSON cannot express — an arrowhead, a direction
+ * indicator, a stretch of emphasised outline.
+ */
+
+/**
+ * A feature synthesised from a stored one. Rebuilt on every render and never persisted,
+ * which is why these may carry fully-namespaced sprite ids directly rather than the readable
+ * aliases `styleGenerator`'s `match` expression resolves for real features.
+ */
+export type SyntheticFeature = Feature<Geometry, GeoJsonProperties>;
+
+/**
+ * A generated arrow: a shaft plus a chevron head.
+ *
+ * `lengthRatio` is read against whatever measure the builder considers the feature's size —
+ * a line's own length for the slide arrow, a ring's bounding-box diagonal for the flow arrow
+ * — so it is documented at each registry entry rather than here.
+ */
+export interface ArrowConfig {
+  /** Fully-namespaced chevron sprite for the arrow head. */
+  icon: string;
+  /** Shaft stroke colour, read back off `properties.color` by the enriched line layer. */
+  color: string;
+  /** Shaft length as a fraction of the feature's size. */
+  lengthRatio: number;
+}
+
+/** What a line type gets decorated with, keyed by `properties.lineType`. */
+export interface EnrichLineConfig {
+  /**
+   * Fully-namespaced sprite image id, e.g. `babs:1101` or `babs:marker-chevron-blue`.
+   *
+   * Unlike `properties.icon` on real features — which stores a readable alias and is
+   * resolved by the `match` expression in styleGenerator — these caps live on synthetic
+   * features, so the sprite key can be used directly.
+   */
+  iconStart?: string;
+  iconEnd?: string;
+  /**
+   * Added to a computed bearing to line the artwork up with it.
+   *
+   * The caps feed in a *reversed* bearing, which is why they add this where the arrows
+   * subtract it. See `arrowFeatures`.
+   */
+  iconRotation: number;
+  /**
+   * Perpendicular direction indicator derived from the geometry. Unlike the caps above this
+   * is not tied to an endpoint, so a line type may carry it with no cap at all.
+   */
+  slideArrow?: ArrowConfig;
+}
+
+/** What a zone type gets decorated with, keyed by `properties.zoneType`. */
+export interface EnrichPolygonConfig {
+  flowArrow?: ArrowConfig;
+}

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -7,7 +7,7 @@ import bbox from "@turf/bbox";
 import classNames from "classnames";
 import EnrichedLayerFeatures, { EnrichedSymbolSource } from "components/map/EnrichedLayerFeatures";
 import type { Feature, FeatureCollection, GeoJsonProperties, Geometry } from "geojson";
-import { first, isEqual } from "lodash";
+import { first, isEqual, throttle } from "lodash";
 import * as maplibre from "maplibre-gl";
 import { setMaxParallelImageRequests, setWorkerCount, setWorkerUrl } from "maplibre-gl";
 import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
@@ -199,13 +199,101 @@ function LayerFetcher() {
   return null;
 }
 
+/**
+ * How often the live geometry is re-read while a vertex is being dragged. Comfortably below
+ * a frame budget, and still fast enough that the indicator reads as following the cursor.
+ */
+const LIVE_GEOMETRY_INTERVAL_MS = 80;
+
+/**
+ * The selected feature's geometry as mapbox-gl-draw currently holds it, rather than as it
+ * was last persisted — or `undefined` when nothing is selected.
+ *
+ * `direct_select` only fires `draw.update` on mouse-up, and the geometry then round-trips
+ * through a mutation and Apollo before it comes back down, so anything driven off the stored
+ * collection lags a vertex drag by a whole gesture. `draw.render` fires every frame while
+ * dragging, which is what makes a live indicator possible.
+ *
+ * Throttled rather than debounced: a debounce would hold the indicator still for the whole
+ * drag and only place it once the pointer stopped, which is the opposite of the point. The
+ * trailing edge still fires, so the final position is exact when a gesture ends between
+ * ticks. The geometry is also compared before it is stored, because `draw.render` fires on
+ * pans and zooms too — without that guard every map movement would rebuild the enriched
+ * source for nothing.
+ */
+function useLiveDrawGeometry(
+  map: ReturnType<typeof useMap>["current"],
+  draw: unknown,
+  selectedFeature: string | number | undefined,
+): Geometry | undefined {
+  // Tagged with the id it was read from, so geometry left over from a previously selected
+  // feature can never be applied to the next one. That also means the effect never has to
+  // clear the state synchronously on deselect.
+  const [live, setLive] = useState<{ id: string; geometry: Geometry } | undefined>(undefined);
+
+  useEffect(() => {
+    if (map === undefined || !isDrawLike(draw) || selectedFeature === undefined) {
+      return;
+    }
+
+    const id = String(selectedFeature);
+
+    const read = () => {
+      try {
+        const current = draw.get(id);
+        if (current === undefined) {
+          return;
+        }
+        setLive((previous) =>
+          previous?.id === id && isEqual(previous.geometry, current.geometry)
+            ? previous
+            : { id, geometry: current.geometry },
+        );
+      } catch {
+        // The draw instance can be mid-teardown; the next tick will re-read.
+      }
+    };
+
+    const onRender = throttle(read, LIVE_GEOMETRY_INTERVAL_MS, { leading: true, trailing: true });
+    map.on("draw.render", onRender);
+    return () => {
+      map.off("draw.render", onRender);
+      onRender.cancel();
+    };
+  }, [map, draw, selectedFeature]);
+
+  return selectedFeature !== undefined && live?.id === String(selectedFeature)
+    ? live.geometry
+    : undefined;
+}
+
 function ActiveLayer() {
   const [initialized, setInitalized] = useState(false);
   const { current: map } = useMap();
   const { state } = useContext(LayerContext);
-  const featureCollection = LayerToFeatureCollection(
-    first(state.layers.filter((l) => l.layer.id === state.activeLayer).map((l) => l.layer)),
+  const featureCollection = useMemo(
+    () =>
+      LayerToFeatureCollection(
+        first(state.layers.filter((l) => l.layer.id === state.activeLayer).map((l) => l.layer)),
+      ),
+    [state.layers, state.activeLayer],
   );
+
+  // Enrichment follows the geometry under the cursor, not the last saved one, so the flow
+  // arrow and the slide arrow track a vertex as it is dragged rather than jumping once the
+  // drag ends.
+  const liveGeometry = useLiveDrawGeometry(map, state.draw, state.selectedFeature);
+  const liveCollection = useMemo(() => {
+    if (liveGeometry === undefined || state.selectedFeature === undefined) {
+      return featureCollection;
+    }
+    return {
+      ...featureCollection,
+      features: featureCollection.features.map((f) =>
+        f.id === state.selectedFeature ? { ...f, geometry: liveGeometry } : f,
+      ),
+    };
+  }, [featureCollection, liveGeometry, state.selectedFeature]);
 
   useEffect(() => {
     const fc = FilterActiveFeatures(featureCollection);
@@ -235,7 +323,7 @@ function ActiveLayer() {
       <Draw />
       <EnrichedLayerFeatures
         id={state.activeLayer}
-        featureCollection={featureCollection}
+        featureCollection={liveCollection}
         selectedFeature={state.selectedFeature}
       />
     </>

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -321,11 +321,7 @@ function ActiveLayer() {
   return (
     <>
       <Draw />
-      <EnrichedLayerFeatures
-        id={state.activeLayer}
-        featureCollection={liveCollection}
-        selectedFeature={state.selectedFeature}
-      />
+      <EnrichedLayerFeatures id={state.activeLayer} featureCollection={liveCollection} />
     </>
   );
 }

--- a/ui/src/views/map/styleGenerator.test.ts
+++ b/ui/src/views/map/styleGenerator.test.ts
@@ -96,7 +96,7 @@ const drawStyle: LayerProps[] = [
       ["==", "active", "false"],
       ["==", "$type", "Polygon"],
       ["has", "user_zoneType"],
-      ["in", "user_zoneType", "Einsatzraum", "Schadengebiet"],
+      ["in", "user_zoneType", "Einsatzraum", "Schadengebiet", "UeberschwemmtesGebiet"],
       ["!=", "mode", "static"],
     ],
     paint: {
@@ -206,6 +206,7 @@ const drawStyle: LayerProps[] = [
         "Radioaktiv",
         "Einsatzraum",
         "Schadengebiet",
+        "UeberschwemmtesGebiet",
       ],
       ["!=", "mode", "static"],
     ],
@@ -365,6 +366,7 @@ const drawStyle: LayerProps[] = [
         "durchgeführteVerschiebung",
         "durchgeführterEinsatz",
         "brandUebergriffErfolgt",
+        "Truemmerbereich",
       ],
       ["!=", "mode", "static"],
     ],
@@ -648,7 +650,7 @@ const displayStyle: LayerProps[] = [
       "all",
       ["==", "$type", "Polygon"],
       ["has", "zoneType"],
-      ["in", "zoneType", "Einsatzraum", "Schadengebiet"],
+      ["in", "zoneType", "Einsatzraum", "Schadengebiet", "UeberschwemmtesGebiet"],
     ],
     paint: {
       "fill-outline-color": ["coalesce", ["get", "color"], "#000000"],
@@ -750,6 +752,7 @@ const displayStyle: LayerProps[] = [
         "Radioaktiv",
         "Einsatzraum",
         "Schadengebiet",
+        "UeberschwemmtesGebiet",
       ],
     ],
     paint: {
@@ -855,6 +858,7 @@ const displayStyle: LayerProps[] = [
         "durchgeführteVerschiebung",
         "durchgeführterEinsatz",
         "brandUebergriffErfolgt",
+        "Truemmerbereich",
       ],
     ],
     layout: {

--- a/ui/src/views/map/styleGenerator.ts
+++ b/ui/src/views/map/styleGenerator.ts
@@ -382,6 +382,8 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
           "durchgeführterEinsatz",
           // Same solid stroke as durchgeführteVerschiebung, in the feature's red.
           "brandUebergriffErfolgt",
+          // Debris field: 1116 has no pattern tile, so the catalogue's plain red boundary.
+          "Truemmerbereich",
         ],
       ]),
       layout: {

--- a/ui/src/views/map/styleImageResolution.test.ts
+++ b/ui/src/views/map/styleImageResolution.test.ts
@@ -11,7 +11,7 @@ import type { LayerProps } from "react-map-gl/maplibre";
 import { describe, expect, it } from "vitest";
 import { babsImage } from "components/babs/iconResolver";
 import { LEGACY_ICON_IDS } from "components/babs/legacyIconNames";
-import { EnrichLineStringMap } from "components/map/EnrichedLayerFeatures";
+import { EnrichLineStringMap, EnrichPolygonMap } from "components/map/EnrichedLayerFeatures";
 import basemap from "../../../public/map/sprites/basemap.json";
 import { createMapStyle } from "./styleGenerator";
 
@@ -353,6 +353,32 @@ describe("style image resolution", () => {
       });
     },
   );
+
+  describe.each(Object.entries(ATLASES))(
+    "enriched polygon arrows against the %s atlas",
+    (_lang, atlas) => {
+      it("uses only sprite images that exist", () => {
+        // Same hole as the line caps: written straight onto synthetic features and read by a
+        // bare ["get", "icon"], so the catch-all style sweep below cannot see them either —
+        // an EnrichPolygonMap sprite never reaches the generated style at all.
+        const available = new Set(availableImagesFor(atlas));
+        const missing = Object.entries(EnrichPolygonMap).flatMap(([zoneType, config]) =>
+          [config.flowArrow?.icon]
+            .filter((icon): icon is string => icon !== undefined)
+            .filter((icon) => !available.has(icon))
+            .map((icon) => `${zoneType}: ${icon}`),
+        );
+        expect(missing).toEqual([]);
+      });
+    },
+  );
+
+  it("gives every zone type in the polygon map some indicator", () => {
+    const withIndicator = Object.entries(EnrichPolygonMap).filter(
+      ([, c]) => c.flowArrow !== undefined,
+    );
+    expect(withIndicator).toHaveLength(Object.keys(EnrichPolygonMap).length);
+  });
 
   it("gives every line type in the map some indicator", () => {
     // Guards against a cap or arrow silently disappearing during a refactor. Rutschgebiet


### PR DESCRIPTION
Adds two missing BABS symbols, plus the editing affordances needed to aim the second one.

## Trümmerbereich (1116)

A plain solid red boundary — 1116 ships no pattern tile and the symbol is an outline rather than a hatch, so it takes no cap and no arrowhead. "No arrowhead" is expressed by absence from the enrichment registry rather than by a config flag. Picker thumbnail is `1116b`.

## Überschwemmtes Gebiet (1115)

Area drawn exactly like `Schadengebiet` (red, outline-only), plus a generated **flow-direction arrow**. The arrow is part of the catalogue symbol rather than decoration — 1115 is *"Zone inondée avec direction du flux"* — which is why it is generated rather than left to the user, exactly as 1113 *"avec direction"* is for Rutschgebiet.

The arrow springs from the **middle of the ring's closing edge** (last vertex back to the first) and leaves it at a right angle, pointing out of the zone. The closing edge is the one you never click — it appears when the ring closes — which makes it easy to predict while drawing and easy to aim afterwards by moving either endpoint. Nothing extra has to be persisted.

Which perpendicular points outward comes from the ring's **winding**, via the shoelace sign, not from a containment probe. Only the sign is needed so no projection is involved, and it is exact where a probe would be ambiguous.

That edge is also **redrawn heavier** — the thickened-outline half of the catalogue symbol, which doubles as the answer to "which edge is the arrow attached to" while editing. It is the only way to show that: mapbox-gl-draw tags vertices with a `coord_path` whose last index depends on the vertex count, so a static style filter can match the ring's first vertex but never its last.

## Editing

Enrichment now renders for the **selected** feature. It was skipped, which meant the indicator vanished for exactly as long as you were editing the geometry that determines it.

That alone wasn't enough: `direct_select` fires `draw.update` only on mouse-up, and the geometry then round-trips through a mutation, so the arrow sat still for the whole drag and jumped at the end. `useLiveDrawGeometry` subscribes to `draw.render` — which *does* fire every frame — and overlays the live geometry before enrichment runs. It is **throttled, not debounced**: a debounce would hold the indicator still until the pointer stopped, which is the opposite of the point. Leading edge keeps it responsive, trailing edge makes the final position exact. The geometry is deep-compared before being stored (`draw.render` also fires on pans and zooms) and tagged with the id it came from, so it can never leak onto the next selection.

## Refactor

`EnrichedLayerFeatures.tsx` had grown to 673 lines holding four unrelated jobs, with the config interfaces declared well after the builders consuming them. Now a 97-line component over one `enrichment/` module per concern: `types`, `arrow`, `slideArrow`, `flowArrow`, `registry`, `enrichFeature`. The entry point is unchanged, so no import site moved.

Redundancies removed along the way, all behaviour-preserving:

- `SlideArrowConfig` and `FlowArrowConfig` were structurally identical, so TypeScript treated them as the same type — the split bought commentary and no safety. Merged.
- The length clamp and self-crossing probe were duplicated between both builders, including two separately-declared ratios that could drift apart silently.
- The start/end cap blocks were near-copies. Both measure their bearing *inwards*, which is exactly why they add the rotation offset where the arrows subtract it.
- `damageExtent` used a bare `90` where `CHEVRON_BEARING_OFFSET` was meant.

## Testing

`yarn vitest run` — 201 pass. New coverage for the polygon branch: anchor on the closing edge, outward normal under either winding, chevron aim, holes ignored, one arrow per MultiPolygon part, triangles, repeated vertices, degenerate rings, and that the registry rather than the geometry type gates it. Six hardcoded entries updated in `styleGenerator.test.ts` across its draw and display halves, and a sibling sprite-existence sweep added for `EnrichPolygonMap`, which the existing `EnrichLineStringMap` sweep could not see.

Verified in the app: direction, side, size and placement all confirmed against real zones.

## Known / not in scope

- The emphasised edge is drawn whether or not the zone is selected — it is part of the symbol now, not an edit-mode affordance.
- On **inactive** layers the enrichment source is mounted before the feature source, so the 2px polygon outline paints over the 4px emphasis line, leaving a thinner halo rather than a clean thick edge. Pre-existing z-order asymmetry, newly visible.
- Smooth/bezier zone outlines were discussed and deferred.
- `RutschgebietGespiegelt` still gets no arrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)