### PR TITLE
fix(map): stop drawing left/right labels after an icon change

### DIFF
--- a/ui/src/components/babs/labelSchema.ts
+++ b/ui/src/components/babs/labelSchema.ts
@@ -43,6 +43,12 @@ const BY_CATEGORY: Partial<Record<BabsCategoryNumber, readonly LabelField[]>> = 
   "7": ANNOTATED_FIELDS, // Fahrzeuge
 };
 
+/** Categories whose icons carry a left and a right label as well as the one below. */
+export const ANNOTATED_CATEGORIES = Object.keys(BY_CATEGORY) as BabsCategoryNumber[];
+
+/** Every position a label can occupy. */
+const LABEL_KEYS: readonly LabelField["key"][] = ["nameLeft", "name", "nameRight"];
+
 export const fieldsFor = (
   category: BabsCategoryNumber | undefined,
   iconId?: BabsIconId,
@@ -50,4 +56,19 @@ export const fieldsFor = (
   if (category && BY_CATEGORY[category]) return BY_CATEGORY[category];
   if (iconId && CASUALTY_ICON_IDS.has(iconId)) return CASUALTY_FIELDS;
   return DEFAULT_FIELDS;
+};
+
+/**
+ * Label positions the given icon's layout has no field for.
+ *
+ * Changing a feature's icon leaves its old labels behind: the popup simply stops offering
+ * the fields, so a Formation's `nameLeft`/`nameRight` survive a switch to an icon that has
+ * neither. Callers clear these alongside the icon.
+ */
+export const unsupportedLabelKeys = (
+  category: BabsCategoryNumber | undefined,
+  iconId?: BabsIconId,
+): LabelField["key"][] => {
+  const supported = new Set(fieldsFor(category, iconId).map((field) => field.key));
+  return LABEL_KEYS.filter((key) => !supported.has(key));
 };

--- a/ui/src/views/map/controls/BabsIconController.tsx
+++ b/ui/src/views/map/controls/BabsIconController.tsx
@@ -14,6 +14,7 @@ import { BabsIcon, BabsIconProvider, useBabsLang } from "@f-eld-ch/babs-react";
 import classNames from "classnames";
 import { aliasFor } from "components/babs/iconResolver";
 import { isPickableCategory, isPickableIcon } from "components/babs/excludedIcons";
+import { unsupportedLabelKeys } from "components/babs/labelSchema";
 import {
   byColor,
   ColorForCategory,
@@ -152,6 +153,11 @@ function IconCategoryMenu(props: CategoryMenuProps) {
         // so it is no longer set.
         icon: aliasFor(id),
         color: ColorForCategory[category.number],
+        // Undefined so `omitBy` strips them: the new icon may annotate in fewer positions
+        // than the old one, and a leftover label would keep being drawn.
+        ...Object.fromEntries(
+          unsupportedLabelKeys(category.number, id).map((key) => [key, undefined]),
+        ),
       });
       onUpdate({
         features: [{ ...feature, properties: omitBy(properties, isEmptyValue) }],

--- a/ui/src/views/map/styleGenerator.test.ts
+++ b/ui/src/views/map/styleGenerator.test.ts
@@ -1,6 +1,8 @@
+import { listIcons } from "@f-eld-ch/babs-core";
 import type { LayerProps } from "react-map-gl/maplibre";
 import { describe, expect, it } from "vitest";
 import { iconIdentifiers } from "components/babs/iconResolver";
+import { ANNOTATED_CATEGORIES } from "components/babs/labelSchema";
 import { Colors } from "components/babs/lineAndZoneTypes";
 import { createMapStyle } from "./styleGenerator";
 
@@ -48,6 +50,11 @@ const TEXT_FIT_PLATE_ICONS = iconIdentifiers(["2109a"]);
 /** Both families, in the order the source builds them — `gl-draw-point-icon` excludes all. */
 const TEXT_FIT_ICONS = iconIdentifiers(["1303", "1304", "2109a"]);
 const SPECIALLY_LABELLED = [...CASUALTIES_RIGHT, ...TEXT_FIT_ICONS];
+
+/** Every identifier of an icon that annotates left and right — Formationen and Fahrzeuge. */
+const ANNOTATED_ICONS = iconIdentifiers(
+  ANNOTATED_CATEGORIES.flatMap((category) => listIcons({ category }).map((meta) => meta.id)),
+);
 
 /**
  * The expected shape of a text-fit layer.
@@ -598,7 +605,7 @@ const drawStyle: LayerProps[] = [
       ["==", "active", "false"],
       ["==", "$type", "Point"],
       ["has", "user_nameLeft"],
-      ["!in", "user_icon", ...SPECIALLY_LABELLED],
+      ["in", "user_icon", ...ANNOTATED_ICONS],
       ["==", "meta", "feature"],
       ["!=", "mode", "static"],
     ],
@@ -622,7 +629,7 @@ const drawStyle: LayerProps[] = [
       ["==", "active", "false"],
       ["==", "$type", "Point"],
       ["has", "user_nameRight"],
-      ["!in", "user_icon", ...SPECIALLY_LABELLED],
+      ["in", "user_icon", ...ANNOTATED_ICONS],
       ["==", "meta", "feature"],
       ["!=", "mode", "static"],
     ],
@@ -1125,7 +1132,7 @@ const displayStyle: LayerProps[] = [
       "all",
       ["==", "$type", "Point"],
       ["has", "nameLeft"],
-      ["!in", "icon", ...SPECIALLY_LABELLED],
+      ["in", "icon", ...ANNOTATED_ICONS],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "nameLeft"], ""],
@@ -1146,7 +1153,7 @@ const displayStyle: LayerProps[] = [
       "all",
       ["==", "$type", "Point"],
       ["has", "nameRight"],
-      ["!in", "icon", ...SPECIALLY_LABELLED],
+      ["in", "icon", ...ANNOTATED_ICONS],
     ],
     layout: {
       "text-field": ["coalesce", ["get", "nameRight"], ""],

--- a/ui/src/views/map/styleGenerator.ts
+++ b/ui/src/views/map/styleGenerator.ts
@@ -1,9 +1,10 @@
-import { type BabsIconId, markerSpriteKey, patternSpriteKey } from "@f-eld-ch/babs-core";
+import { type BabsIconId, listIcons, markerSpriteKey, patternSpriteKey } from "@f-eld-ch/babs-core";
 import {
   babsImage,
   iconIdentifiers,
   legacyIconMatchExpression,
 } from "components/babs/iconResolver";
+import { ANNOTATED_CATEGORIES } from "components/babs/labelSchema";
 import { ZoneTypes } from "components/babs/lineAndZoneTypes";
 import type { ExpressionSpecification, FilterSpecification } from "maplibre-gl";
 import type { LayerProps } from "react-map-gl/maplibre";
@@ -164,6 +165,17 @@ const TEXT_FIT_PLATE_TEXT_SIZE: ExpressionSpecification = [
 
 /** The icons the generic name label must skip, because another layer already labels them. */
 const SPECIALLY_LABELLED = [...CASUALTIES_RIGHT, ...TEXT_FIT_ICONS];
+
+/**
+ * Every identifier denoting an icon whose layout has a left and a right label.
+ *
+ * The two layers select on this rather than on the mere presence of `nameLeft` /
+ * `nameRight`, because a feature keeps those values when its icon changes: a Formation
+ * relabelled as a damage sign went on showing all three labels.
+ */
+const ANNOTATED_ICONS = iconIdentifiers(
+  ANNOTATED_CATEGORIES.flatMap((category) => listIcons({ category }).map((meta) => meta.id)),
+);
 
 /**
  * On-screen scale of a point marker.
@@ -714,7 +726,7 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
       filter: createFilter([
         ["==", "$type", "Point"],
         ["has", `${propPrefix}nameLeft`],
-        ["!in", `${propPrefix}icon`, ...SPECIALLY_LABELLED],
+        ["in", `${propPrefix}icon`, ...ANNOTATED_ICONS],
       ]),
       layout: {
         "text-field": ["coalesce", ["get", `${propPrefix}nameLeft`], ""],
@@ -734,7 +746,7 @@ export function createMapStyle(options: MapStyleOptions = { forDraw: true }): La
       filter: createFilter([
         ["==", "$type", "Point"],
         ["has", `${propPrefix}nameRight`],
-        ["!in", `${propPrefix}icon`, ...SPECIALLY_LABELLED],
+        ["in", `${propPrefix}icon`, ...ANNOTATED_ICONS],
       ]),
       layout: {
         "text-field": ["coalesce", ["get", `${propPrefix}nameRight`], ""],


### PR DESCRIPTION
## Problem

Formationen (category 4) and Fahrzeuge (category 7) annotate in three positions — Nähere Kennzeichnung (left), Ortsbezeichnung (below), Zusatzangaben (right). Every other icon has a single label.

Switching such a feature to an icon without that layout only changed what `FeatureLabelPopup` offered: `nameLeft` and `nameRight` stayed on the feature, and `gl-draw-text-name-point-left` / `-right` selected purely on `["has", "…nameLeft"]`, so the map kept drawing all three labels.

## Fix

Two layers of defence, because the property fix alone cannot help features already saved in this state.

**Data.** `labelSchema` gains `unsupportedLabelKeys(category, iconId)` — the positions the new icon's layout has no field for. `onClickIcon` writes them as `undefined` alongside `icon`, and the existing `omitBy(properties, isEmptyValue)` strips them.

**Style.** The two side-label layers now also require the icon to be one that actually annotates left and right:

```ts
["in", `${propPrefix}icon`, ...ANNOTATED_ICONS]
```

`ANNOTATED_ICONS` is derived from `ANNOTATED_CATEGORIES` via `listIcons` + `iconIdentifiers`, so it covers alias, bare id and legacy German name, and picks up catalogue additions on its own rather than being a hand-kept list. Stale labels on already-persisted features stop rendering immediately — no data migration.

The previous `["!in", …SPECIALLY_LABELLED]` guard on those two layers became redundant (casualty and text-fit icons are categories 1 and 2, never 4 or 7) and was replaced rather than added to.

## Verification

- `styleGenerator.test.ts` fixture updated for the new filters.
- Full UI suite: 214 passing.
