### PR TITLE
feat(map): refine rotation and line direction controls

### DIFF
--- a/ui/src/components/babs/labelSchema.ts
+++ b/ui/src/components/babs/labelSchema.ts
@@ -24,6 +24,21 @@ const CASUALTY_ICON_IDS = new Set<BabsIconId>([
   "1305", // Tote
 ]);
 
+const CASUALTY_ICON_VALUES = new Set([
+  ...CASUALTY_ICON_IDS,
+  "babsVerletzte",
+  "babsVermisste",
+  "babsObdachlose",
+  "babsEingesperrte",
+  "babsTote",
+  "Verletzte",
+  "Vermisste",
+  "Obdachlose",
+  "Eingesperrte",
+  "Tote",
+  "EingesperrteAbgeschnittene",
+]);
+
 const CASUALTY_FIELDS: readonly LabelField[] = [
   { key: "name", labelKey: "name", placeholderKey: "mapview.labels.anzahlPersonen" },
 ];
@@ -57,6 +72,17 @@ export const fieldsFor = (
   if (iconId && CASUALTY_ICON_IDS.has(iconId)) return CASUALTY_FIELDS;
   return DEFAULT_FIELDS;
 };
+
+/** Icons whose symbols already carry their own fixed label placement. */
+export const rotationAllowed = (
+  category: BabsCategoryNumber | undefined,
+  iconId?: BabsIconId,
+  iconValue?: string,
+): boolean =>
+  category !== "4" &&
+  category !== "7" &&
+  !(iconId && CASUALTY_ICON_IDS.has(iconId)) &&
+  !(iconValue && (iconValue.startsWith("un:") || CASUALTY_ICON_VALUES.has(iconValue)));
 
 /**
  * Label positions the given icon's layout has no field for.

--- a/ui/src/components/babs/lineAndZoneTypes.ts
+++ b/ui/src/components/babs/lineAndZoneTypes.ts
@@ -33,6 +33,8 @@ export interface SelectableType {
   thumbnail: BabsIconId;
   /** Stroke colour, and the value persisted as `properties.color`. */
   color: string;
+  /** Whether reversing the line changes its meaning. */
+  directional?: boolean;
   /**
    * How the zone's interior is drawn. At most one of these may be set.
    *
@@ -143,16 +145,19 @@ export const LineTypes: SelectableTypes = {
     name: "brandUebergriffGefahr",
     thumbnail: "1111a",
     color: Colors.Red,
+    directional: true,
   },
   brandUebergriffErfolgt: {
     name: "brandUebergriffErfolgt",
     thumbnail: "1111b",
     color: Colors.Red,
+    directional: true,
   },
   Rutschgebiet: {
     name: "Rutschgebiet",
     thumbnail: "1113",
     color: Colors.Red,
+    directional: true,
   },
   /**
    * Debris field. A plain solid boundary: 1116 ships no pattern tile in the catalogue, and
@@ -182,36 +187,43 @@ export const LineTypes: SelectableTypes = {
     name: "beabsichtigteErkundung",
     thumbnail: "6103a",
     color: Colors.Blue,
+    directional: true,
   },
   durchgeführteErkundung: {
     name: "durchgeführteErkundung",
     thumbnail: "6103b",
     color: Colors.Blue,
+    directional: true,
   },
   beabsichtigteVerschiebung: {
     name: "beabsichtigteVerschiebung",
     thumbnail: "6101a",
     color: Colors.Blue,
+    directional: true,
   },
   durchgeführteVerschiebung: {
     name: "durchgeführteVerschiebung",
     thumbnail: "6101b",
     color: Colors.Blue,
+    directional: true,
   },
   beabsichtigterEinsatz: {
     name: "beabsichtigterEinsatz",
     thumbnail: "6102a",
     color: Colors.Blue,
+    directional: true,
   },
   durchgeführterEinsatz: {
     name: "durchgeführterEinsatz",
     thumbnail: "6102b",
     color: Colors.Blue,
+    directional: true,
   },
   rettungsAchse: {
     name: "rettungsAchse",
     thumbnail: "6106",
     color: Colors.Blue,
+    directional: true,
   },
 };
 

--- a/ui/src/i18n/locales/de/translations.json
+++ b/ui/src/i18n/locales/de/translations.json
@@ -39,6 +39,7 @@
   "map": "Lagebild",
   "mapview": {
     "rotate": "Richtung drehen",
+    "rotation": "Drehung",
     "layer": "Layer",
     "unlock": "Fixierte Signatur lösen",
     "lock": "Signatur fixieren",

--- a/ui/src/i18n/locales/en/translations.json
+++ b/ui/src/i18n/locales/en/translations.json
@@ -39,6 +39,7 @@
   "map": "situation map",
   "mapview": {
     "rotate": "Turn direction",
+    "rotation": "Rotation",
     "layer": "Layer",
     "unlock": "Unlock symbol",
     "lock": "Lock Symbol",

--- a/ui/src/i18n/locales/fr/translations.json
+++ b/ui/src/i18n/locales/fr/translations.json
@@ -39,6 +39,7 @@
   "map": "Suivi dessiné",
   "mapview": {
     "rotate": "Tourner la signe",
+    "rotation": "Rotation",
     "layer": "calque",
     "unlock": "Désamarrer le signe",
     "lock": "Verrouiller le signe",

--- a/ui/src/i18n/locales/it/translations.json
+++ b/ui/src/i18n/locales/it/translations.json
@@ -39,6 +39,7 @@
   "map": "immagine della situazione",
   "mapview": {
     "rotate": "Direzione di rotazione",
+    "rotation": "Rotazione",
     "layer": "Livello",
     "unlock": "Rilasciare l'allineamento",
     "lock": "Fissare l'allineamento",

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -1,17 +1,17 @@
 import "./control-panel.css";
 import "./Map.scss";
-import { setBabsSpriteLang, withBabsSprite } from "@f-eld-ch/babs-sprites";
 import { useMutation, useQuery, useReactiveVar } from "@apollo/client/react";
+import { setBabsSpriteLang, withBabsSprite } from "@f-eld-ch/babs-sprites";
 import MapboxDraw from "@mapbox/mapbox-gl-draw";
 import bbox from "@turf/bbox";
 import classNames from "classnames";
+import { BABS_SPRITE_BASE } from "components/babs/iconResolver";
 import EnrichedLayerFeatures, { EnrichedSymbolSource } from "components/map/EnrichedLayerFeatures";
 import type { Feature, FeatureCollection, GeoJsonProperties, Geometry } from "geojson";
 import { first, isEqual, throttle } from "lodash";
 import * as maplibre from "maplibre-gl";
 import { setMaxParallelImageRequests, setWorkerCount, setWorkerUrl } from "maplibre-gl";
 import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
-
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -47,7 +47,6 @@ import SearchControl from "./controls/Searchbox";
 import { StyleController, selectedStyle } from "./controls/StyleController";
 import { AddFeatureToLayer, DeleteFeature, GetLayers, ModifyFeature } from "./graphql";
 import { LayerContext, LayersProvider } from "./LayerContext";
-import { BABS_SPRITE_BASE } from "components/babs/iconResolver";
 import { createMapStyle } from "./styleGenerator";
 import { CleanFeature, FilterActiveFeatures, LayerToFeatureCollection } from "./utils";
 
@@ -111,7 +110,7 @@ function MapView() {
         unSigns: true,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- language is deliberately excluded
-    [mapStyle.style],
+    [mapStyle.style, i18n.resolvedLanguage, i18n.language],
   );
 
   const mapClass = classNames({
@@ -267,7 +266,10 @@ function useLiveDrawGeometry(
       }
     };
 
-    const onRender = throttle(read, LIVE_GEOMETRY_INTERVAL_MS, { leading: true, trailing: true });
+    const onRender = throttle(read, LIVE_GEOMETRY_INTERVAL_MS, {
+      leading: true,
+      trailing: true,
+    });
     // mapbox-gl-draw fires its events *through* the map, but they are not part of MapLibre's
     // own event map, so `on`/`off` do not accept the name. Narrowed to just the two methods
     // rather than casting the map to `any`, so a typo in either is still caught.
@@ -508,7 +510,9 @@ function Draw() {
         // Restore draw-mode selection after the layer reset so the feature stays
         // visually selected (handles visible) when a property update triggers a redraw.
         if (state.selectedFeature && d.get(state.selectedFeature)) {
-          d.changeMode("simple_select", { featureIds: [state.selectedFeature] });
+          d.changeMode("simple_select", {
+            featureIds: [state.selectedFeature],
+          });
         }
       });
     }

--- a/ui/src/views/map/controls/BabsIconController.tsx
+++ b/ui/src/views/map/controls/BabsIconController.tsx
@@ -1,6 +1,3 @@
-import { faFileText } from "@fortawesome/free-regular-svg-icons";
-import { faChevronLeft, faHeading } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   type BabsCategory,
   type BabsIconId,
@@ -11,10 +8,13 @@ import {
   listIcons,
 } from "@f-eld-ch/babs-core";
 import { BabsIcon, BabsIconProvider, useBabsLang } from "@f-eld-ch/babs-react";
+import { faFileText } from "@fortawesome/free-regular-svg-icons";
+import { faChevronLeft, faHeading } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import classNames from "classnames";
-import { aliasFor } from "components/babs/iconResolver";
 import { isPickableCategory, isPickableIcon } from "components/babs/excludedIcons";
-import { unsupportedLabelKeys } from "components/babs/labelSchema";
+import { aliasFor } from "components/babs/iconResolver";
+import { rotationAllowed, unsupportedLabelKeys } from "components/babs/labelSchema";
 import {
   byColor,
   ColorForCategory,
@@ -32,11 +32,12 @@ import {
 } from "components/babs/pickerConfig";
 import { useBabsIcons } from "components/babs/useBabsIcons";
 import type { Feature, GeoJsonProperties, Geometry } from "geojson";
-import { FeatureLabelPopup } from "./FeatureLabelPopup";
 import { first, isUndefined, omitBy } from "lodash";
 import { memo, useCallback, useContext, useState } from "react";
+import { FeatureLabelPopup } from "./FeatureLabelPopup";
 
 const isEmptyValue = (v: unknown): boolean => isUndefined(v) || v === "";
+
 import { useTranslation } from "react-i18next";
 import { useMap } from "react-map-gl/maplibre";
 import { fireDrawEvent } from "../drawEvents";
@@ -153,6 +154,9 @@ function IconCategoryMenu(props: CategoryMenuProps) {
         // so it is no longer set.
         icon: aliasFor(id),
         color: ColorForCategory[category.number],
+        iconRotation: rotationAllowed(category.number, id)
+          ? feature.properties?.iconRotation
+          : undefined,
         // Undefined so `omitBy` strips them: the new icon may annotate in fewer positions
         // than the old one, and a leftover label would keep being drawn.
         ...Object.fromEntries(
@@ -285,7 +289,10 @@ const LineController = memo((props: BabsIconControllerProps) => {
         { ...selectedFeature.properties, lineType: i.name, color: i.color },
         isEmptyValue,
       );
-      onUpdate({ features: [{ ...selectedFeature, properties }], action: "featureDetail" });
+      onUpdate({
+        features: [{ ...selectedFeature, properties }],
+        action: "featureDetail",
+      });
     },
     [onUpdate, selectedFeature],
   );
@@ -338,7 +345,10 @@ const ZoneController = memo((props: BabsIconControllerProps) => {
           { ...selectedFeature.properties, zoneType: i.name, color: i.color },
           isEmptyValue,
         );
-        onUpdate({ features: [{ ...selectedFeature, properties }], action: "featureDetail" });
+        onUpdate({
+          features: [{ ...selectedFeature, properties }],
+          action: "featureDetail",
+        });
       }
     },
     [onUpdate, selectedFeature],
@@ -427,7 +437,10 @@ const BabsIconController = () => {
       const updatedFeatures: Feature[] = e.features;
       // Route the edit back through the draw control's own update path, so feature
       // changes made here persist by exactly the same mechanism as direct edits.
-      fireDrawEvent(map?.getMap(), "draw.update", { features: updatedFeatures, target: map });
+      fireDrawEvent(map?.getMap(), "draw.update", {
+        features: updatedFeatures,
+        target: map,
+      });
     },
     [map],
   );
@@ -467,7 +480,10 @@ const FeatureDetailControlPanel = memo((props: BabsIconControllerProps) => {
           { ...selectedFeature.properties, name },
           isEmptyValue,
         );
-        onUpdate({ features: [{ ...selectedFeature, properties }], action: "featureDetail" });
+        onUpdate({
+          features: [{ ...selectedFeature, properties }],
+          action: "featureDetail",
+        });
       }
 
       setEnteredText("");

--- a/ui/src/views/map/controls/FeatureLabelPopup.tsx
+++ b/ui/src/views/map/controls/FeatureLabelPopup.tsx
@@ -1,10 +1,10 @@
 import { getIcon } from "@f-eld-ch/babs-core";
 import { KEMLER_CODES } from "@f-eld-ch/babs-core/kemler-codes";
-import { faArrowsRotate, faLock, faLockOpen } from "@fortawesome/free-solid-svg-icons";
+import { faArrowsRotate, faLock } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import bbox from "@turf/bbox";
 import { categoryOf, resolveIconId } from "components/babs/iconResolver";
-import { fieldsFor, type LabelField } from "components/babs/labelSchema";
+import { fieldsFor, type LabelField, rotationAllowed } from "components/babs/labelSchema";
 import { LineTypes, ZoneTypes } from "components/babs/lineAndZoneTypes";
 import type { Feature, GeoJsonProperties, Geometry } from "geojson";
 import { isUndefined, omitBy } from "lodash";
@@ -82,6 +82,9 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
   const resolvedIconId = resolveIconId(iconValue);
   const isUnSign = resolvedIconId === UN_SIGN_ICON || iconValue?.startsWith("un:");
   const fields = fieldsFor(category, resolvedIconId);
+  const canRotate =
+    selectedFeature.geometry.type === "Point" &&
+    rotationAllowed(category, resolvedIconId, iconValue);
 
   const valuesFromFeature = () =>
     isUnSign
@@ -93,15 +96,17 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
       : Object.fromEntries(fields.map((f) => [f.key, selectedFeature.properties?.[f.key] ?? ""]));
 
   const [values, setValues] = useState<Record<string, string>>(valuesFromFeature);
-  const [rotationLock, setRotationLock] = useState<boolean>(
-    !isUndefined(selectedFeature?.properties?.iconRotation),
+  const [rotation, setRotation] = useState<number>(selectedFeature?.properties?.iconRotation ?? 0);
+  const [rotationFixed, setRotationFixed] = useState<boolean>(
+    canRotate && !isUndefined(selectedFeature?.properties?.iconRotation),
   );
 
   const [syncedFeature, setSyncedFeature] = useState(selectedFeature);
   if (selectedFeature !== syncedFeature) {
     setSyncedFeature(selectedFeature);
     setValues(valuesFromFeature());
-    setRotationLock(!isUndefined(selectedFeature?.properties?.iconRotation));
+    setRotation(selectedFeature?.properties?.iconRotation ?? 0);
+    setRotationFixed(canRotate && !isUndefined(selectedFeature?.properties?.iconRotation));
   }
 
   const close = useCallback(() => {
@@ -118,15 +123,20 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
             stoffbezeichnung: values[UN_SIGN_FIELDS.substance],
             nameLeft: undefined,
             nameRight: undefined,
+            iconRotation: canRotate ? selectedFeature.properties?.iconRotation : undefined,
           }
-        : { ...selectedFeature.properties, ...values },
+        : {
+            ...selectedFeature.properties,
+            ...values,
+            iconRotation: canRotate ? selectedFeature.properties?.iconRotation : undefined,
+          },
       isEmptyValue,
     );
     onUpdate({
       features: [{ ...selectedFeature, properties }],
       action: "featureDetail",
     });
-  }, [isUnSign, onUpdate, selectedFeature, values]);
+  }, [canRotate, isUnSign, onUpdate, selectedFeature, values]);
 
   const saveAndClose = useCallback(() => {
     commit();
@@ -144,9 +154,8 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
     onUpdate({ features: [reversed], action: "featureDetail" });
   }, [onUpdate, selectedFeature]);
 
-  const onRotateClick = (lock: boolean) => {
-    if (!map) return;
-    setRotationLock(lock);
+  const onRotationChange = (value: number) => {
+    setRotation(value);
     const properties: GeoJsonProperties = omitBy(
       isUnSign
         ? {
@@ -156,13 +165,36 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
             stoffbezeichnung: values[UN_SIGN_FIELDS.substance],
             nameLeft: undefined,
             nameRight: undefined,
-            iconRotation: lock ? map.getBearing() : undefined,
+            iconRotation: value,
           }
         : {
             ...selectedFeature.properties,
             ...values,
-            iconRotation: lock ? map.getBearing() : undefined,
+            iconRotation: value,
           },
+      isEmptyValue,
+    );
+    onUpdate({
+      features: [{ ...selectedFeature, properties }],
+      action: "featureDetail",
+    });
+  };
+
+  const onRotationFix = () => {
+    if (!map) return;
+    setRotationFixed(true);
+    onRotationChange(map.getBearing());
+  };
+
+  const onRotationUnlock = () => {
+    setRotationFixed(false);
+    setRotation(0);
+    const properties: GeoJsonProperties = omitBy(
+      {
+        ...selectedFeature.properties,
+        ...values,
+        iconRotation: undefined,
+      },
       isEmptyValue,
     );
     onUpdate({
@@ -226,6 +258,8 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
   } = popupAnchorFor(selectedFeature);
   const isPoint = selectedFeature.geometry.type === "Point";
   const isLine = selectedFeature.geometry.type === "LineString";
+  const isDirectionalLine =
+    isLine && LineTypes[selectedFeature.properties?.lineType as string]?.directional === true;
 
   useEffect(() => {
     if (!map) return;
@@ -256,9 +290,7 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
         );
       }
     }
-    // selectedFeature.id gates re-runs so property edits don't re-pan
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [map, isPoint, lng, lat, selectedFeature.id]);
+  }, [map, isPoint, lng, lat, selectedFeature]);
 
   return (
     <Popup
@@ -341,24 +373,57 @@ export function FeatureLabelPopup({ selectedFeature, onUpdate }: FeatureLabelPop
             </div>
           );
         })}
-        {isPoint && (
+        {canRotate && (
           <div className="field mb-2">
-            <div className="control">
-              <button
-                type="button"
-                className="button is-small is-fullwidth is-light"
-                title={rotationLock ? t("mapview.unlock") : t("mapview.lock")}
-                onClick={() => onRotateClick(!rotationLock)}
-              >
-                <span className="icon is-small">
-                  <FontAwesomeIcon icon={rotationLock ? faLock : faLockOpen} />
-                </span>
-                <span>{rotationLock ? t("mapview.unlock") : t("mapview.lock")}</span>
-              </button>
-            </div>
+            {rotationFixed ? (
+              <>
+                <label className="label is-small mb-1" htmlFor={`${baseId}-rotation`}>
+                  <span className="icon is-small mr-1">
+                    <FontAwesomeIcon icon={faArrowsRotate} />
+                  </span>
+                  {t("mapview.rotation")} <span className="has-text-grey">({rotation}°)</span>
+                </label>
+                <div className="control">
+                  <input
+                    id={`${baseId}-rotation`}
+                    className="slider is-fullwidth"
+                    type="range"
+                    min="0"
+                    max="360"
+                    step="1"
+                    value={rotation}
+                    aria-label={t("mapview.rotation")}
+                    onChange={(e) => onRotationChange(Number(e.target.value))}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="button is-small is-fullwidth is-light mt-2"
+                  onClick={onRotationUnlock}
+                >
+                  <span className="icon is-small">
+                    <FontAwesomeIcon icon={faLock} />
+                  </span>
+                  <span>{t("mapview.unlock")}</span>
+                </button>
+              </>
+            ) : (
+              <div className="control">
+                <button
+                  type="button"
+                  className="button is-small is-fullwidth is-light"
+                  onClick={onRotationFix}
+                >
+                  <span className="icon is-small">
+                    <FontAwesomeIcon icon={faLock} />
+                  </span>
+                  <span>{t("mapview.lock")}</span>
+                </button>
+              </div>
+            )}
           </div>
         )}
-        {isLine && (
+        {isDirectionalLine && (
           <div className="field mb-2">
             <div className="control">
               <button


### PR DESCRIPTION
## Summary

- provide two-stage rotation controls for eligible point icons
- prevent rotation locking for casualties, formations, vehicles, and UN-number signs
- add rotation unlock support
- show line direction reversal only for directional line types and Rutschgebiet
- keep point popups fully visible by panning without changing zoom

## Verification

- `yarn fmt`
- `yarn lint`
- full UI test suite: 214 tests passed