### PR TITLE
feat(ui): improve closed incident handling

### DIFF
--- a/docs/development/GettingStarted.md
+++ b/docs/development/GettingStarted.md
@@ -9,15 +9,15 @@ A simple local development environment uses Docker Compose for infrastructure (P
 2. Create a `config.yaml` in the repo root for the Go server (this file is gitignored):
 
 ```yaml
-oidc_issuer: "http://localhost:5556/dex"
-oidc_client_id: "sitrep"
-oidc_client_secret: "ds8LCRW4jhB58nWdMgZHeVISqx3O3e1o3g0LEr9H8tM="  # generate with: openssl rand -base64 32 | tr -- '+/' '-_'
-oidc_redirect_url: "http://localhost:3000/oauth2/callback"
-cookie_key: "0123456789abcdef0123456789abcdef"                        # generate with: openssl rand -hex 16
+oidc-issuer: "http://localhost:5556/dex"
+oidc-client-id: "sitrep"
+oidc-client-secret: "ds8LCRW4jhB58nWdMgZHeVISqx3O3e1o3g0LEr9H8tM="  # generate with: openssl rand -base64 32 | tr -- '+/' '-_'
+oidc-redirect-url: "http://localhost:3000/oauth2/callback"
+cookie-key: "0123456789abcdef0123456789abcdef"                        # generate with: openssl rand -hex 16
 
-database_url: "postgres://postgres:postgrespassword@localhost:5432/postgres?sslmode=disable"
+database-url: "postgres://postgres:postgrespassword@localhost:5432/postgres?sslmode=disable"
 
-graphql_introspection: true  # enables /api/v2/graphql/play
+graphql-introspection: true  # enables /api/v2/graphql/play
 ```
 
 3. Create a `.env.local` in the repo root for Docker Compose (sets the Postgres password and Dex OIDC client):
@@ -40,10 +40,17 @@ On SELinux machines use the selinux compose file:
 docker compose -f docker-compose.selinux.yml --env-file .env.local up -d
 ```
 
-5. Start the Go backend server (reads `config.yaml` from the working directory):
+5. Start the Go backend server (by default, reads `config.yaml` from the working directory):
 
 ```
 go run .
+```
+
+To use a configuration file elsewhere, pass its path explicitly. An explicit path must exist and
+contain valid YAML:
+
+```
+go run . --config /path/to/config.yaml
 ```
 
 Or build and run the binary:
@@ -60,7 +67,28 @@ cd ui && yarn start
 
 7. Open [localhost:3000](http://localhost:3000/). The Vite dev server proxies `/api/v2/graphql` and `/oauth2` to the Go server at `:4180`. Authentication is handled by the local Dex IDP — click **Log in with Example**.
 
-The GraphQL playground is available at [localhost:4180/api/v2/graphql/play](http://localhost:4180/api/v2/graphql/play) when `graphql_introspection: true` is set in `config.yaml`.
+The GraphQL playground is available at [localhost:4180/api/v2/graphql/play](http://localhost:4180/api/v2/graphql/play) when `graphql-introspection: true` is set in `config.yaml`.
+
+### Server Configuration
+
+Every configuration-backed CLI flag also has a YAML key with the same name and a canonical
+`SITREP_*` environment variable. Values take precedence in this order: CLI flags, environment
+variables, configuration file, then defaults.
+
+| Flag / YAML key | Canonical environment variable | Legacy environment variables |
+| --- | --- | --- |
+| `log-level` | `SITREP_LOG_LEVEL` | `LOG_LEVEL` |
+| `database-url` | `SITREP_DATABASE_URL` | `DATABASE_URL` |
+| `port` | `SITREP_PORT` | `SITREP_SERVER_PORT`, `SERVER_PORT` |
+| `oidc-client-id` | `SITREP_OIDC_CLIENT_ID` | `OIDC_CLIENT_ID`, `OAUTH2_PROXY_CLIENT_ID` |
+| `oidc-issuer` | `SITREP_OIDC_ISSUER` | `OIDC_ISSUER`, `OAUTH2_PROXY_OIDC_ISSUER_URL` |
+| `oidc-client-secret` | `SITREP_OIDC_CLIENT_SECRET` | `OIDC_CLIENT_SECRET`, `OAUTH2_PROXY_CLIENT_SECRET` |
+| `oidc-redirect-url` | `SITREP_OIDC_REDIRECT_URL` | `OIDC_REDIRECT_URL`, `OAUTH2_PROXY_REDIRECT_URL` |
+| `cookie-key` | `SITREP_COOKIE_KEY` | `COOKIE_KEY`, `OAUTH2_PROXY_COOKIE_SECRET`, `OIDC_COOKIE_KEY` |
+| `graphql-introspection` | `SITREP_GRAPHQL_INTROSPECTION` | `GRAPHQL_INTROSPECTION` |
+
+`log-level` and `database-url` are root flags. The remaining flags are specific to `sitrep serve`.
+`--config` selects the YAML file and does not have an environment-variable counterpart.
 
 ### Observability (optional)
 

--- a/internal/adapter/inbound/graphql/resolver_test.go
+++ b/internal/adapter/inbound/graphql/resolver_test.go
@@ -366,8 +366,8 @@ func TestUpdateMessage_CorrectContent(t *testing.T) {
 		IncidentID:     inc.ID,
 		Sender:         "Alice",
 		Receiver:       "Bob",
-		SenderDetail:   "",
-		ReceiverDetail: "",
+		SenderDetail:   "555-1111",
+		ReceiverDetail: "555-2222",
 		Content:        "Original",
 		Medium:         model.MediumPhone,
 	})
@@ -404,8 +404,8 @@ func TestDeleteMessage(t *testing.T) {
 		IncidentID:     inc.ID,
 		Sender:         "X",
 		Receiver:       "Y",
-		SenderDetail:   "",
-		ReceiverDetail: "",
+		SenderDetail:   "sender@example.test",
+		ReceiverDetail: "receiver@example.test",
 		Content:        "To Remove",
 		Medium:         model.MediumEmail,
 	})

--- a/internal/adapter/outbound/eventstore/inmem/projection/message.go
+++ b/internal/adapter/outbound/eventstore/inmem/projection/message.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/f-eld-ch/sitrep/internal/core/domain/shared"
 	"github.com/f-eld-ch/sitrep/internal/eventsourcing"
 )
 
@@ -46,7 +47,7 @@ func NewMessageHandler() *MessageHandler {
 }
 
 func (h *MessageHandler) Name() string { return "rm_message" }
-func (h *MessageHandler) Version() int { return 1 }
+func (h *MessageHandler) Version() int { return 2 }
 
 func (h *MessageHandler) Reset(_ context.Context) error {
 	h.mu.Lock()
@@ -170,7 +171,7 @@ func (h *MessageHandler) Apply(_ context.Context, e eventsourcing.Event) error {
 			return nil
 		}
 		row.Triage = d.Triage
-		row.Priority = d.Priority
+		row.Priority = priorityForTriage(d.Triage, d.Priority)
 		row.DivisionIDs = d.DivisionIDs
 		row.LastEditorSub = &d.TriagedBy
 		row.UpdatedAt = e.OccurredAt
@@ -182,6 +183,13 @@ func (h *MessageHandler) Apply(_ context.Context, e eventsourcing.Event) error {
 		}
 	}
 	return nil
+}
+
+func priorityForTriage(triage, priority string) string {
+	if triage == string(shared.TriageMoreInfo) {
+		return string(shared.PriorityNormal)
+	}
+	return priority
 }
 
 // Get returns the row for the given message ID, or nil if not found.

--- a/internal/adapter/outbound/eventstore/inmem/projection/projector_test.go
+++ b/internal/adapter/outbound/eventstore/inmem/projection/projector_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/f-eld-ch/sitrep/internal/adapter/outbound/eventstore"
 	"github.com/f-eld-ch/sitrep/internal/adapter/outbound/eventstore/inmem"
 	"github.com/f-eld-ch/sitrep/internal/adapter/outbound/eventstore/inmem/projection"
+	"github.com/f-eld-ch/sitrep/internal/core/domain/message"
 	"github.com/f-eld-ch/sitrep/internal/core/domain/shared"
 	"github.com/f-eld-ch/sitrep/internal/core/port/inbound"
 	"github.com/f-eld-ch/sitrep/internal/core/service"
+	"github.com/f-eld-ch/sitrep/internal/eventsourcing"
 	"github.com/f-eld-ch/sitrep/internal/platform/identity"
 )
 
@@ -194,7 +196,7 @@ func TestProjector_MessageCorrected(t *testing.T) {
 
 	res, _ := incSvc.CreateIncident(ctx(), "Brand", nil, nil, nil, testActor)
 	msg, _ := msgSvc.RecordMessage(ctx(), res.IncidentID,
-		"Rauch gesehen", "Beobachter", "", "Stab", "", shared.MediumPhone, nil, testActor)
+		"Rauch gesehen", "Beobachter", "555-1111", "Stab", "555-2222", shared.MediumPhone, nil, testActor)
 
 	newContent := "Rauch und Flammen gesehen"
 	_, err := msgSvc.CorrectMessage(ctx(), msg.ID,
@@ -228,6 +230,33 @@ func TestProjector_MessageTriaged(t *testing.T) {
 	assert.Equal(t, string(shared.PriorityHigh), row.Priority)
 }
 
+func TestProjector_MessageMoreInfoNormalizesLegacyHighPriority(t *testing.T) {
+	s := newStack(t)
+	incSvc, msgSvc := s.messageSvc()
+
+	res, _ := incSvc.CreateIncident(ctx(), "Unfall", nil, nil, nil, testActor)
+	msg, _ := msgSvc.RecordMessage(ctx(), res.IncidentID,
+		"Fahrzeug umgekippt", "Streife", "", "Leitstelle", "", shared.MediumRadio, nil, testActor)
+	require.NoError(t, s.proj.CatchUp(ctx()))
+
+	err := s.messages.Apply(ctx(), eventsourcing.Event{
+		StreamType: "Message",
+		StreamID:   uuid.UUID(msg.ID),
+		EventType:  "Triaged",
+		Data: message.Triaged{
+			Triage:   shared.TriageMoreInfo,
+			Priority: shared.PriorityHigh,
+		},
+		OccurredAt: testAt,
+	})
+	require.NoError(t, err)
+
+	row := s.messages.Get(uuid.UUID(msg.ID))
+	require.NotNil(t, row)
+	assert.Equal(t, string(shared.TriageMoreInfo), row.Triage)
+	assert.Equal(t, string(shared.PriorityNormal), row.Priority)
+}
+
 func TestProjector_MessageDeleted(t *testing.T) {
 	s := newStack(t)
 	incSvc, msgSvc := s.messageSvc()
@@ -255,7 +284,7 @@ func TestProjector_MessagesSegregatedByIncident(t *testing.T) {
 
 	_, err := msgSvc.RecordMessage(ctx(), res1.IncidentID, "Msg A", "S", "", "R", "", shared.MediumRadio, nil, testActor)
 	require.NoError(t, err)
-	_, err = msgSvc.RecordMessage(ctx(), res1.IncidentID, "Msg B", "S", "", "R", "", shared.MediumPhone, nil, testActor)
+	_, err = msgSvc.RecordMessage(ctx(), res1.IncidentID, "Msg B", "S", "555-1111", "R", "555-2222", shared.MediumPhone, nil, testActor)
 	require.NoError(t, err)
 	_, err = msgSvc.RecordMessage(ctx(), res2.IncidentID, "Msg C", "S", "", "R", "", shared.MediumRadio, nil, testActor)
 	require.NoError(t, err)

--- a/internal/adapter/outbound/eventstore/postgres/projection/message.go
+++ b/internal/adapter/outbound/eventstore/postgres/projection/message.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/f-eld-ch/sitrep/internal/core/domain/shared"
 	"github.com/f-eld-ch/sitrep/internal/eventsourcing"
 )
 
@@ -24,7 +25,7 @@ func NewMessageHandler(pool *pgxpool.Pool) *MessageHandler {
 }
 
 func (h *MessageHandler) Name() string { return "rm_message" }
-func (h *MessageHandler) Version() int { return 1 }
+func (h *MessageHandler) Version() int { return 2 }
 func (h *MessageHandler) Reset(ctx context.Context) error {
 	_, err := h.pool.Exec(ctx, `TRUNCATE rm_message`)
 	return err
@@ -109,6 +110,7 @@ func (h *MessageHandler) Apply(ctx context.Context, e eventsourcing.Event) error
 		if updatedAt.IsZero() {
 			updatedAt = createdAt
 		}
+		d.Priority = priorityForTriage(d.Triage, d.Priority)
 		return exec(db, ctx, `
 			INSERT INTO rm_message
 			  (id, incident_id, number, content, sender, sender_detail, receiver, receiver_detail,
@@ -164,6 +166,7 @@ func (h *MessageHandler) Apply(ctx context.Context, e eventsourcing.Event) error
 		if err := remarshal(e.Data, &d); err != nil {
 			return err
 		}
+		d.Priority = priorityForTriage(d.Triage, d.Priority)
 		return exec(db, ctx, `
 			UPDATE rm_message
 			SET triage = $2, priority = $3, division_ids = $4, last_editor_sub = $5,
@@ -175,4 +178,11 @@ func (h *MessageHandler) Apply(ctx context.Context, e eventsourcing.Event) error
 		return exec(db, ctx, `DELETE FROM rm_message WHERE id = $1`, id)
 	}
 	return nil
+}
+
+func priorityForTriage(triage, priority string) string {
+	if triage == string(shared.TriageMoreInfo) {
+		return string(shared.PriorityNormal)
+	}
+	return priority
 }

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -10,8 +10,8 @@ import (
 var logLevel = new(slog.LevelVar) // defaults to slog.LevelInfo
 
 // initLogger installs a plain-text stdout handler that honours logLevel.
-// It is called from cobra.OnInitialize (after viper has read config + flags),
-// and again by setupOpenTelemetry when it builds the OTLP fanout.
+// It is called after configuration is loaded, and again by setupOpenTelemetry
+// when it builds the OTLP fanout.
 func initLogger() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: logLevel})))
 }

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -16,44 +16,18 @@ import (
 	"github.com/f-eld-ch/sitrep/migrations"
 )
 
-var migrateCmd = &cobra.Command{
-	Use:   "migrate",
-	Short: "Database migration commands",
+func newMigrateCmd(v *viper.Viper) *cobra.Command {
+	migrateCmd := &cobra.Command{Use: "migrate", Short: "Database migration commands"}
+	migrateCmd.AddCommand(
+		newMigrateUpCmd(v),
+		newMigrateDownCmd(v),
+		newMigrateStatusCmd(v),
+		newMigratePreflightCmd(v),
+	)
+	return migrateCmd
 }
 
-var migrateUpCmd = &cobra.Command{
-	Use:   "up",
-	Short: "Apply all pending migrations",
-	RunE:  runMigrateUp,
-}
-
-var migrateDownCmd = &cobra.Command{
-	Use:   "down",
-	Short: "Roll back the last applied migration",
-	RunE:  runMigrateDown,
-}
-
-var migrateStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Print migration status",
-	RunE:  runMigrateStatus,
-}
-
-var migratePreflightCmd = &cobra.Command{
-	Use:   "preflight",
-	Short: "Run import data checks without migrating (safe to run against production)",
-	RunE:  runMigratePreflight,
-}
-
-func init() {
-	migrateCmd.AddCommand(migrateUpCmd)
-	migrateCmd.AddCommand(migrateDownCmd)
-	migrateCmd.AddCommand(migrateStatusCmd)
-	migrateCmd.AddCommand(migratePreflightCmd)
-}
-
-func openGooseDB(ctx context.Context) (*sql.DB, error) {
-	dsn := viper.GetString("database_url")
+func openGooseDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if dsn == "" {
 		return nil, fmt.Errorf("--database-url / DATABASE_URL is required for migrate commands")
 	}
@@ -79,8 +53,18 @@ func gooseProvider(db *sql.DB) (*goose.Provider, error) {
 	)
 }
 
-func runMigrateUp(cmd *cobra.Command, _ []string) error {
-	db, err := openGooseDB(cmd.Context())
+func newMigrateUpCmd(v *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "up",
+		Short: "Apply all pending migrations",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMigrateUp(cmd, v.GetString("database-url"))
+		},
+	}
+}
+
+func runMigrateUp(cmd *cobra.Command, dsn string) error {
+	db, err := openGooseDB(cmd.Context(), dsn)
 	if err != nil {
 		return err
 	}
@@ -96,8 +80,18 @@ func runMigrateUp(cmd *cobra.Command, _ []string) error {
 	return err
 }
 
-func runMigrateDown(cmd *cobra.Command, _ []string) error {
-	db, err := openGooseDB(cmd.Context())
+func newMigrateDownCmd(v *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "down",
+		Short: "Roll back the last applied migration",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMigrateDown(cmd, v.GetString("database-url"))
+		},
+	}
+}
+
+func runMigrateDown(cmd *cobra.Command, dsn string) error {
+	db, err := openGooseDB(cmd.Context(), dsn)
 	if err != nil {
 		return err
 	}
@@ -114,8 +108,18 @@ func runMigrateDown(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runMigrateStatus(cmd *cobra.Command, _ []string) error {
-	db, err := openGooseDB(cmd.Context())
+func newMigrateStatusCmd(v *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Print migration status",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMigrateStatus(cmd, v.GetString("database-url"))
+		},
+	}
+}
+
+func runMigrateStatus(cmd *cobra.Command, dsn string) error {
+	db, err := openGooseDB(cmd.Context(), dsn)
 	if err != nil {
 		return err
 	}
@@ -138,8 +142,18 @@ func runMigrateStatus(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runMigratePreflight(cmd *cobra.Command, _ []string) error {
-	db, err := openGooseDB(cmd.Context())
+func newMigratePreflightCmd(v *viper.Viper) *cobra.Command {
+	return &cobra.Command{
+		Use:   "preflight",
+		Short: "Run import data checks without migrating (safe to run against production)",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runMigratePreflight(cmd, v.GetString("database-url"))
+		},
+	}
+}
+
+func runMigratePreflight(cmd *cobra.Command, dsn string) error {
+	db, err := openGooseDB(cmd.Context(), dsn)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,73 +1,200 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "sitrep",
-	Short: "SitRep — incident management server",
-	// Running bare `sitrep` serves (backward compat: existing manifests need no change).
-	RunE: serveCmd.RunE,
+type configOption struct {
+	name        string
+	value       any
+	description string
+	legacyEnv   []string
+	addFlag     func(*pflag.FlagSet)
+}
+
+func stringOption(name, defaultValue, description string, legacyEnv ...string) configOption {
+	return configOption{
+		name:        name,
+		value:       defaultValue,
+		description: description,
+		legacyEnv:   legacyEnv,
+		addFlag: func(flags *pflag.FlagSet) {
+			flags.String(name, defaultValue, description)
+		},
+	}
+}
+
+func uintOption(name string, defaultValue uint, description string, legacyEnv ...string) configOption {
+	return configOption{
+		name:        name,
+		value:       defaultValue,
+		description: description,
+		legacyEnv:   legacyEnv,
+		addFlag: func(flags *pflag.FlagSet) {
+			flags.Uint(name, defaultValue, description)
+		},
+	}
+}
+
+func boolOption(name string, defaultValue bool, description string, legacyEnv ...string) configOption {
+	return configOption{
+		name:        name,
+		value:       defaultValue,
+		description: description,
+		legacyEnv:   legacyEnv,
+		addFlag: func(flags *pflag.FlagSet) {
+			flags.Bool(name, defaultValue, description)
+		},
+	}
+}
+
+var rootConfigOptions = []configOption{
+	stringOption("log-level", "info", "Log level (debug, info, warn, error)", "LOG_LEVEL"),
+	stringOption("database-url", "", "PostgreSQL connection string (DSN or URL)", "DATABASE_URL"),
 }
 
 func Execute() {
+	rootCmd, err := NewRootCmd()
+	cobra.CheckErr(err)
 	cobra.CheckErr(rootCmd.Execute())
 }
 
-func init() {
-	cobra.OnInitialize(func() {
-		viper.SetConfigName("config")
-		viper.SetConfigType("yaml")
-		viper.AddConfigPath(".")
-		viper.AutomaticEnv()
-		_ = viper.ReadInConfig()
+func NewRootCmd() (*cobra.Command, error) {
+	rootCmd := &cobra.Command{
+		Use:          "sitrep",
+		Short:        "SitRep — incident management server",
+		SilenceUsage: true,
+	}
 
-		var level slog.Level
-		if err := level.UnmarshalText([]byte(viper.GetString("log_level"))); err != nil {
-			level = slog.LevelInfo
-		}
-		logLevel.Set(level)
-		initLogger()
-
-		_ = viper.BindEnv("oidc_client_id", "OIDC_CLIENT_ID", "OAUTH2_PROXY_CLIENT_ID")
-		_ = viper.BindEnv("oidc_issuer", "OIDC_ISSUER", "OAUTH2_PROXY_OIDC_ISSUER_URL")
-		_ = viper.BindEnv("oidc_client_secret", "OIDC_CLIENT_SECRET", "OAUTH2_PROXY_CLIENT_SECRET")
-		_ = viper.BindEnv("oidc_redirect_url", "OIDC_REDIRECT_URL", "OAUTH2_PROXY_REDIRECT_URL")
-		_ = viper.BindEnv("cookie_key", "COOKIE_KEY", "OAUTH2_PROXY_COOKIE_SECRET", "OIDC_COOKIE_KEY")
-		_ = viper.BindEnv("server_port", "SERVER_PORT")
-		_ = viper.BindEnv("database_url", "DATABASE_URL")
-		viper.SetDefault("server_port", 4180)
-	})
-
-	// Persistent flags — visible on every subcommand.
 	pf := rootCmd.PersistentFlags()
-	pf.String("log-level", "info", "Log level (debug, info, warn, error)")
-	pf.Uint("port", 4180, "Server port")
-	pf.String("oidc-client-id", "", "OIDC client ID")
-	pf.String("oidc-issuer", "", "OIDC issuer URL")
-	pf.String("oidc-client-secret", "", "OIDC client secret")
-	pf.String("oidc-redirect-url", "", "OIDC redirect URL")
-	pf.String("cookie-key", "", "Cookie signing key")
-	pf.String("database-url", "", "PostgreSQL connection string (DSN or URL)")
-	pf.Bool("graphql-introspection", false, "Enable GraphQL introspection and playground (dev only)")
+	pf.String("config", "", "Path to configuration file")
+	if err := rootCmd.MarkPersistentFlagFilename("config", "yaml", "yml"); err != nil {
+		return nil, fmt.Errorf("configure --config completion: %w", err)
+	}
 
-	// Bind to the same viper keys the existing BindEnv aliases already cover.
-	_ = viper.BindEnv("log_level", "LOG_LEVEL")
-	_ = viper.BindEnv("graphql_introspection", "GRAPHQL_INTROSPECTION")
-	_ = viper.BindPFlag("log_level", pf.Lookup("log-level"))
-	_ = viper.BindPFlag("server_port", pf.Lookup("port"))
-	_ = viper.BindPFlag("oidc_client_id", pf.Lookup("oidc-client-id"))
-	_ = viper.BindPFlag("oidc_issuer", pf.Lookup("oidc-issuer"))
-	_ = viper.BindPFlag("oidc_client_secret", pf.Lookup("oidc-client-secret"))
-	_ = viper.BindPFlag("oidc_redirect_url", pf.Lookup("oidc-redirect-url"))
-	_ = viper.BindPFlag("cookie_key", pf.Lookup("cookie-key"))
-	_ = viper.BindPFlag("database_url", pf.Lookup("database-url"))
-	_ = viper.BindPFlag("graphql_introspection", pf.Lookup("graphql-introspection"))
-
+	v, err := newViper(rootConfigOptions)
+	if err != nil {
+		return nil, err
+	}
+	if err := bindFlags(v, pf, rootConfigOptions); err != nil {
+		return nil, err
+	}
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		configPath, err := cmd.Flags().GetString("config")
+		if err != nil {
+			return fmt.Errorf("read --config: %w", err)
+		}
+		if err := loadConfig(v, configPath); err != nil {
+			return err
+		}
+		return configureLogger(v.GetString("log-level"))
+	}
+	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return runServe(cmd, args, v)
+	}
+	serveCmd, err := newServeCmd(v)
+	if err != nil {
+		return nil, err
+	}
 	rootCmd.AddCommand(serveCmd)
-	rootCmd.AddCommand(migrateCmd)
+	rootCmd.AddCommand(newMigrateCmd(v))
+	return rootCmd, nil
+}
+
+func newViper(options ...[]configOption) (*viper.Viper, error) {
+	v := viper.New()
+	for _, optionGroup := range options {
+		if err := configureOptions(v, optionGroup); err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
+}
+
+func configureOptions(v *viper.Viper, options []configOption) error {
+	for _, option := range options {
+		v.SetDefault(option.name, option.value)
+		envNames := append([]string{option.name, canonicalEnvName(option.name)}, option.legacyEnv...)
+		if err := v.BindEnv(envNames...); err != nil {
+			return fmt.Errorf("bind %s environment variables: %w", option.name, err)
+		}
+	}
+	return nil
+}
+
+func bindFlags(v *viper.Viper, flags *pflag.FlagSet, options []configOption) error {
+	for _, option := range options {
+		option.addFlag(flags)
+		if err := v.BindPFlag(option.name, flags.Lookup(option.name)); err != nil {
+			return fmt.Errorf("bind --%s: %w", option.name, err)
+		}
+	}
+	return nil
+}
+
+func canonicalEnvName(option string) string {
+	return "SITREP_" + strings.ToUpper(strings.ReplaceAll(option, "-", "_"))
+}
+
+func loadConfig(v *viper.Viper, configPath string) error {
+	if configPath != "" {
+		v.SetConfigFile(configPath)
+	} else {
+		v.SetConfigName("config")
+		v.SetConfigType("yaml")
+		v.AddConfigPath(".")
+	}
+	if err := v.ReadInConfig(); err != nil {
+		var lookupError viper.ConfigFileNotFoundError
+		if configPath != "" || !errors.As(err, &lookupError) {
+			return fmt.Errorf("read configuration: %w", err)
+		}
+	}
+	return validateConfig(v)
+}
+
+func validateConfig(v *viper.Viper) error {
+	if port := v.GetUint("port"); port == 0 || port > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	var level slog.Level
+	logLevel := v.GetString("log-level")
+	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
+		return fmt.Errorf("invalid log-level %q: %w", logLevel, err)
+	}
+
+	oidcFields := []string{
+		v.GetString("oidc-client-id"),
+		v.GetString("oidc-issuer"),
+		v.GetString("oidc-client-secret"),
+		v.GetString("oidc-redirect-url"),
+		v.GetString("cookie-key"),
+	}
+	configured := 0
+	for _, field := range oidcFields {
+		if field != "" {
+			configured++
+		}
+	}
+	if configured != 0 && configured != len(oidcFields) {
+		return fmt.Errorf("oidc-client-id, oidc-issuer, oidc-client-secret, oidc-redirect-url, and cookie-key must be configured together")
+	}
+	return nil
+}
+
+func configureLogger(levelText string) error {
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(levelText)); err != nil {
+		return fmt.Errorf("parse log level: %w", err)
+	}
+	logLevel.Set(level)
+	initLogger()
+	return nil
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("loads an explicit configuration file", func(t *testing.T) {
+		configPath := writeConfig(t, "port: 4321\nlog-level: debug\n")
+		v := testViper(t)
+
+		err := loadConfig(v, configPath)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint(4321), v.GetUint("port"))
+		assert.Equal(t, "debug", v.GetString("log-level"))
+	})
+
+	t.Run("rejects a missing explicit configuration file", func(t *testing.T) {
+		err := loadConfig(testViper(t), filepath.Join(t.TempDir(), "missing.yaml"))
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "read configuration")
+	})
+
+	t.Run("environment variables override the configuration file", func(t *testing.T) {
+		t.Setenv("SITREP_PORT", "5432")
+		configPath := writeConfig(t, "port: 4321\n")
+
+		v := testViper(t)
+		err := loadConfig(v, configPath)
+
+		require.NoError(t, err)
+		assert.Equal(t, uint(5432), v.GetUint("port"))
+	})
+}
+
+func TestConfigValidate(t *testing.T) {
+	t.Run("rejects partial OIDC configuration", func(t *testing.T) {
+		v := testViper(t)
+		v.Set("oidc-client-id", "sitrep")
+		err := validateConfig(v)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "must be configured together")
+	})
+
+	t.Run("rejects an invalid server port", func(t *testing.T) {
+		v := testViper(t)
+		v.Set("port", 65536)
+		err := validateConfig(v)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "port")
+	})
+}
+
+func TestNewRootCmd(t *testing.T) {
+	rootCmd, err := NewRootCmd()
+
+	require.NoError(t, err)
+	configFlag := rootCmd.PersistentFlags().Lookup("config")
+	require.NotNil(t, configFlag)
+	assert.Equal(t, "", configFlag.DefValue)
+	assert.NotNil(t, rootCmd.PersistentFlags().Lookup("database-url"))
+	assert.Nil(t, rootCmd.PersistentFlags().Lookup("port"))
+
+	serveCmd, _, err := rootCmd.Find([]string{"serve"})
+	require.NoError(t, err)
+	assert.NotNil(t, serveCmd.Flags().Lookup("port"))
+	assert.Nil(t, serveCmd.Flags().Lookup("database-url"))
+}
+
+func testViper(t *testing.T) *viper.Viper {
+	t.Helper()
+	v, err := newViper(rootConfigOptions, serveConfigOptions)
+	require.NoError(t, err)
+	return v
+}
+
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(contents), 0o600))
+	return configPath
+}

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -26,13 +26,34 @@ func SetBuildInfo(version, sha string) {
 	Sha = sha
 }
 
-var serveCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Start the SitRep API server",
-	RunE:  runServe,
+var serveConfigOptions = []configOption{
+	uintOption("port", 4180, "Server port", "SITREP_SERVER_PORT", "SERVER_PORT"),
+	stringOption("oidc-client-id", "", "OIDC client ID", "OIDC_CLIENT_ID", "OAUTH2_PROXY_CLIENT_ID"),
+	stringOption("oidc-issuer", "", "OIDC issuer URL", "OIDC_ISSUER", "OAUTH2_PROXY_OIDC_ISSUER_URL"),
+	stringOption("oidc-client-secret", "", "OIDC client secret", "OIDC_CLIENT_SECRET", "OAUTH2_PROXY_CLIENT_SECRET"),
+	stringOption("oidc-redirect-url", "", "OIDC redirect URL", "OIDC_REDIRECT_URL", "OAUTH2_PROXY_REDIRECT_URL"),
+	stringOption("cookie-key", "", "Cookie signing key", "COOKIE_KEY", "OAUTH2_PROXY_COOKIE_SECRET", "OIDC_COOKIE_KEY"),
+	boolOption("graphql-introspection", false, "Enable GraphQL introspection and playground (dev only)", "GRAPHQL_INTROSPECTION"),
 }
 
-func runServe(cmd *cobra.Command, _ []string) error {
+func newServeCmd(v *viper.Viper) (*cobra.Command, error) {
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the SitRep API server",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runServe(cmd, args, v)
+		},
+	}
+	if err := configureOptions(v, serveConfigOptions); err != nil {
+		return nil, err
+	}
+	if err := bindFlags(v, serveCmd.Flags(), serveConfigOptions); err != nil {
+		return nil, err
+	}
+	return serveCmd, nil
+}
+
+func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 	ctx := cmd.Context()
 	slog.InfoContext(ctx, "starting sitrep", "version", Version, "sha", Sha)
 
@@ -47,26 +68,26 @@ func runServe(cmd *cobra.Command, _ []string) error {
 		}
 	}()
 
-	s, err := buildStack(ctx)
+	s, err := buildStack(ctx, v.GetString("database-url"))
 	if err != nil {
 		return err
 	}
 	defer s.Teardown()
 
 	opts := []server.Option{
-		server.WithPort(viper.GetUint("server_port")),
+		server.WithPort(v.GetUint("port")),
 		server.WithApiV2(s.IncidentSvc, s.MessageSvc, s.LayerSvc, s.FeatureSvc, s.Queries,
-			viper.GetBool("graphql_introspection")),
+			v.GetBool("graphql-introspection")),
 		server.WithVersion(Version, Sha),
 	}
 
-	if viper.GetString("oidc_client_id") != "" && viper.GetString("oidc_issuer") != "" {
+	if v.GetString("oidc-client-id") != "" {
 		oidcClient, err := auth.NewOIDC(ctx,
-			viper.GetString("oidc_issuer"),
-			viper.GetString("oidc_client_id"),
-			viper.GetString("oidc_client_secret"),
-			viper.GetString("oidc_redirect_url"),
-			deriveCookieKey(viper.GetString("cookie_key")),
+			v.GetString("oidc-issuer"),
+			v.GetString("oidc-client-id"),
+			v.GetString("oidc-client-secret"),
+			v.GetString("oidc-redirect-url"),
+			deriveCookieKey(v.GetString("cookie-key")),
 		)
 		if err != nil {
 			slog.ErrorContext(ctx, "failed to create OIDC client", "error", err)

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/spf13/viper"
 
 	"github.com/f-eld-ch/sitrep/internal/adapter/outbound/eventstore"
 	"github.com/f-eld-ch/sitrep/internal/adapter/outbound/eventstore/inmem"
@@ -39,8 +38,7 @@ type stack struct {
 // buildStack wires the full application stack. When DATABASE_URL is set it uses
 // PostgreSQL; otherwise it falls back to in-memory stores (useful for local dev
 // without a running database).
-func buildStack(ctx context.Context) (*stack, error) {
-	dsn := viper.GetString("database_url")
+func buildStack(ctx context.Context, dsn string) (*stack, error) {
 	if dsn == "" {
 		slog.WarnContext(ctx, "No database_url set, using in-memory stores (data will not persist)")
 		return buildInmemStack(ctx)

--- a/internal/core/domain/incident/incident.go
+++ b/internal/core/domain/incident/incident.go
@@ -6,6 +6,7 @@ package incident
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,8 +102,11 @@ func (i *Incident) Open(
 	at time.Time,
 	actor string,
 ) error {
-	if name == "" {
+	if strings.TrimSpace(name) == "" {
 		return shared.ValidationError{Field: "name", Message: "must not be empty"}
+	}
+	if err := validateDivisions(divisions); err != nil {
+		return err
 	}
 	meta := baseMeta(actor)
 	eventsourcing.TrackChange(i, Opened{Name: name, Location: loc}, at, meta)
@@ -117,7 +121,7 @@ func (i *Incident) Rename(name, actor string, at time.Time) error {
 	if err := i.requireOpen(); err != nil {
 		return err
 	}
-	if name == "" {
+	if strings.TrimSpace(name) == "" {
 		return shared.ValidationError{Field: "name", Message: "must not be empty"}
 	}
 	eventsourcing.TrackChange(i, Renamed{Name: name}, at, baseMeta(actor))
@@ -145,6 +149,9 @@ func (i *Incident) UpdateDivisions(desired []DivisionData, actor string, at time
 	if err := i.requireOpen(); err != nil {
 		return err
 	}
+	if err := validateDivisions(desired); err != nil {
+		return err
+	}
 	meta := baseMeta(actor)
 
 	// Build a lookup of desired divisions by ID.
@@ -167,6 +174,18 @@ func (i *Incident) UpdateDivisions(desired []DivisionData, actor string, at time
 			eventsourcing.TrackChange(i, DivisionAdded{Division: d}, at, meta)
 		} else if existing.Name != d.Name || existing.Description != d.Description {
 			eventsourcing.TrackChange(i, DivisionRenamed{ID: d.ID, Name: d.Name, Description: &d.Description}, at, meta)
+		}
+	}
+	return nil
+}
+
+func validateDivisions(divisions []DivisionData) error {
+	for _, division := range divisions {
+		if strings.TrimSpace(division.Name) == "" {
+			return shared.ValidationError{Field: "division.name", Message: "must not be empty"}
+		}
+		if strings.TrimSpace(division.Description) == "" {
+			return shared.ValidationError{Field: "division.description", Message: "must not be empty"}
 		}
 	}
 	return nil

--- a/internal/core/domain/incident/incident_test.go
+++ b/internal/core/domain/incident/incident_test.go
@@ -46,6 +46,7 @@ func TestIncident_Open(t *testing.T) {
 	}{
 		{"valid name creates event", "Hochwasser Reuss", nil},
 		{"empty name is rejected", "", shared.ErrInvalidInput},
+		{"whitespace name is rejected", " \t", shared.ErrInvalidInput},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +150,15 @@ func TestIncident_UpdateDivisions(t *testing.T) {
 			types = append(types, e.EventType)
 		}
 		assert.Contains(t, types, "DivisionAdded")
+	})
+
+	t.Run("whitespace division fields are rejected", func(t *testing.T) {
+		inc := replay(t, id, []eventsourcing.Event{opened(id, "Hochwasser")})
+		err := inc.UpdateDivisions([]incident.DivisionData{
+			{ID: divID, Name: " ", Description: "Kartenstelle"},
+		}, actor, at)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+		assert.Empty(t, inc.Root().PendingEvents())
 	})
 
 	t.Run("removing a division emits DivisionRemoved", func(t *testing.T) {

--- a/internal/core/domain/message/message.go
+++ b/internal/core/domain/message/message.go
@@ -6,6 +6,7 @@ package message
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -82,7 +83,10 @@ func (m *Message) Record(
 	at time.Time,
 	actor string,
 ) error {
-	if err := validateMessageFields(content, sender, receiver); err != nil {
+	if err := validateMessageFields(content, sender, senderDetail, receiver, receiverDetail, medium); err != nil {
+		return err
+	}
+	if err := validateMessageTime(msgTime, at); err != nil {
 		return err
 	}
 	eventsourcing.TrackChange(m, Recorded{
@@ -112,14 +116,37 @@ func (m *Message) Correct(
 	if m.deleted {
 		return shared.ErrNotFound
 	}
-	if content != nil && *content == "" {
-		return shared.ValidationError{Field: "content", Message: "must not be empty"}
+	nextContent := m.content
+	if content != nil {
+		nextContent = *content
 	}
-	if sender != nil && *sender == "" {
-		return shared.ValidationError{Field: "sender", Message: "must not be empty"}
+	nextSender := m.sender
+	if sender != nil {
+		nextSender = *sender
 	}
-	if receiver != nil && *receiver == "" {
-		return shared.ValidationError{Field: "receiver", Message: "must not be empty"}
+	nextSenderDetail := m.senderDetail
+	if senderDetail != nil {
+		nextSenderDetail = *senderDetail
+	}
+	nextReceiver := m.receiver
+	if receiver != nil {
+		nextReceiver = *receiver
+	}
+	nextReceiverDetail := m.receiverDetail
+	if receiverDetail != nil {
+		nextReceiverDetail = *receiverDetail
+	}
+	nextMedium := m.medium
+	if medium != nil {
+		nextMedium = *medium
+	}
+	if err := validateMessageFields(nextContent, nextSender, nextSenderDetail, nextReceiver, nextReceiverDetail, nextMedium); err != nil {
+		return err
+	}
+	if msgTime != nil {
+		if err := validateMessageTime(*msgTime, at); err != nil {
+			return err
+		}
 	}
 	eventsourcing.TrackChange(m, Corrected{
 		Content:        content,
@@ -238,15 +265,32 @@ func (m *Message) Transition(e eventsourcing.Event) error {
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────────
 
-func validateMessageFields(content, sender, receiver string) error {
-	if content == "" {
+const maxMessageClockDrift = 5 * time.Minute
+
+func validateMessageFields(content, sender, senderDetail, receiver, receiverDetail string, medium shared.Medium) error {
+	if strings.TrimSpace(content) == "" {
 		return shared.ValidationError{Field: "content", Message: "must not be empty"}
 	}
-	if sender == "" {
+	if strings.TrimSpace(sender) == "" {
 		return shared.ValidationError{Field: "sender", Message: "must not be empty"}
 	}
-	if receiver == "" {
+	if strings.TrimSpace(receiver) == "" {
 		return shared.ValidationError{Field: "receiver", Message: "must not be empty"}
+	}
+	if medium == shared.MediumPhone || medium == shared.MediumEmail {
+		if strings.TrimSpace(senderDetail) == "" {
+			return shared.ValidationError{Field: "senderDetail", Message: "must not be empty"}
+		}
+		if strings.TrimSpace(receiverDetail) == "" {
+			return shared.ValidationError{Field: "receiverDetail", Message: "must not be empty"}
+		}
+	}
+	return nil
+}
+
+func validateMessageTime(msgTime, at time.Time) error {
+	if msgTime.After(at.Add(maxMessageClockDrift)) {
+		return shared.ValidationError{Field: "time", Message: "must not be more than five minutes in the future"}
 	}
 	return nil
 }

--- a/internal/core/domain/message/message.go
+++ b/internal/core/domain/message/message.go
@@ -173,6 +173,9 @@ func (m *Message) Triage(
 	if m.deleted {
 		return shared.ErrNotFound
 	}
+	if triage == shared.TriageMoreInfo {
+		priority = shared.PriorityNormal
+	}
 	eventsourcing.TrackChange(m, Triaged{
 		Triage:      triage,
 		Priority:    priority,

--- a/internal/core/domain/message/message_test.go
+++ b/internal/core/domain/message/message_test.go
@@ -50,8 +50,11 @@ func TestMessage_Record(t *testing.T) {
 	}{
 		{"valid fields", "Wasserstand steigt", "Beobachter Nord", "Führungsstab", nil},
 		{"empty content rejected", "", "Sender", "Receiver", shared.ErrInvalidInput},
+		{"whitespace content rejected", " \t", "Sender", "Receiver", shared.ErrInvalidInput},
 		{"empty sender rejected", "Content", "", "Receiver", shared.ErrInvalidInput},
+		{"whitespace sender rejected", "Content", " \t", "Receiver", shared.ErrInvalidInput},
 		{"empty receiver rejected", "Content", "Sender", "", shared.ErrInvalidInput},
+		{"whitespace receiver rejected", "Content", "Sender", " \t", shared.ErrInvalidInput},
 	}
 
 	for _, tt := range tests {
@@ -70,6 +73,33 @@ func TestMessage_Record(t *testing.T) {
 			assert.Equal(t, "Recorded", pending[0].EventType)
 		})
 	}
+
+	t.Run("Phone and Email messages require details", func(t *testing.T) {
+		m := message.New(id)
+		err := m.Record(incidentID, 1, "Content", "Sender", "", "Receiver", "555-2222",
+			shared.MediumPhone, at, actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+
+		m = message.New(id)
+		err = m.Record(incidentID, 1, "Content", "Sender", "sender@example.test", "Receiver", " \t",
+			shared.MediumEmail, at, actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+	})
+
+	t.Run("rejects timestamps more than five minutes in the future", func(t *testing.T) {
+		m := message.New(id)
+		err := m.Record(incidentID, 1, "Content", "Sender", "", "Receiver", "", shared.MediumRadio,
+			at.Add(5*time.Minute+time.Nanosecond), actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+		assert.Empty(t, m.Root().PendingEvents())
+	})
+
+	t.Run("allows timestamps up to five minutes in the future", func(t *testing.T) {
+		m := message.New(id)
+		err := m.Record(incidentID, 1, "Content", "Sender", "", "Receiver", "", shared.MediumRadio,
+			at.Add(5*time.Minute), actor, at, actor)
+		require.NoError(t, err)
+	})
 }
 
 func TestMessage_Correct(t *testing.T) {
@@ -97,6 +127,26 @@ func TestMessage_Correct(t *testing.T) {
 	t.Run("empty sender is rejected", func(t *testing.T) {
 		m := replay(t, id, []eventsourcing.Event{recorded(id)})
 		err := m.Correct(nil, str(""), nil, nil, nil, nil, nil, actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+	})
+
+	t.Run("whitespace receiver is rejected", func(t *testing.T) {
+		m := replay(t, id, []eventsourcing.Event{recorded(id)})
+		err := m.Correct(nil, nil, nil, str(" \t"), nil, nil, nil, actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+	})
+
+	t.Run("changing to Phone requires details", func(t *testing.T) {
+		m := replay(t, id, []eventsourcing.Event{recorded(id)})
+		medium := shared.MediumPhone
+		err := m.Correct(nil, nil, nil, nil, nil, &medium, nil, actor, at, actor)
+		require.ErrorIs(t, err, shared.ErrInvalidInput)
+	})
+
+	t.Run("cannot correct a timestamp more than five minutes in the future", func(t *testing.T) {
+		m := replay(t, id, []eventsourcing.Event{recorded(id)})
+		futureTime := at.Add(5*time.Minute + time.Nanosecond)
+		err := m.Correct(nil, nil, nil, nil, nil, nil, &futureTime, actor, at, actor)
 		require.ErrorIs(t, err, shared.ErrInvalidInput)
 	})
 

--- a/internal/core/domain/message/message_test.go
+++ b/internal/core/domain/message/message_test.go
@@ -174,6 +174,13 @@ func TestMessage_Triage(t *testing.T) {
 		assert.Equal(t, divID, m.DivisionIDs()[0])
 	})
 
+	t.Run("needs more information resets priority to normal", func(t *testing.T) {
+		m := replay(t, id, []eventsourcing.Event{recorded(id)})
+		err := m.Triage(shared.TriageMoreInfo, shared.PriorityHigh, nil, actor, at, actor)
+		require.NoError(t, err)
+		assert.Equal(t, shared.PriorityNormal, m.PriorityStatus())
+	})
+
 	t.Run("triage on deleted message is rejected", func(t *testing.T) {
 		m := replay(t, id, []eventsourcing.Event{recorded(id)})
 		require.NoError(t, m.Delete(shared.DeleteReasonManual, actor, at))

--- a/internal/core/service/feature.go
+++ b/internal/core/service/feature.go
@@ -62,12 +62,8 @@ func (s *FeatureService) PlaceFeature(
 
 	at := s.clock.Now()
 	err := s.tx.WithinTx(ctx, func(ctx context.Context) error {
-		inc, err := s.incidents.Load(ctx, incidentID)
-		if err != nil {
+		if err := s.requireIncidentOpen(ctx, incidentID); err != nil {
 			return err
-		}
-		if !inc.IsOpen() {
-			return shared.ErrIncidentNotOpen
 		}
 		l, err := s.layers.Load(ctx, layerID)
 		if err != nil {
@@ -158,6 +154,9 @@ func (s *FeatureService) writeFeature(ctx context.Context, id shared.FeatureID, 
 		if err != nil {
 			return err
 		}
+		if err := s.requireIncidentOpen(ctx, f.IncidentID()); err != nil {
+			return err
+		}
 		if err := fn(f); err != nil {
 			return err
 		}
@@ -168,5 +167,16 @@ func (s *FeatureService) writeFeature(ctx context.Context, id shared.FeatureID, 
 		return err
 	}
 	_ = s.notifier.Notify(ctx)
+	return nil
+}
+
+func (s *FeatureService) requireIncidentOpen(ctx context.Context, incidentID shared.IncidentID) error {
+	inc, err := s.incidents.Load(ctx, incidentID)
+	if err != nil {
+		return err
+	}
+	if !inc.IsOpen() {
+		return shared.ErrIncidentNotOpen
+	}
 	return nil
 }

--- a/internal/core/service/feature_test.go
+++ b/internal/core/service/feature_test.go
@@ -69,3 +69,23 @@ func TestFeatureService_ModifyUnknown(t *testing.T) {
 	_, err := featureSvc.ModifyFeature(ctx(), shared.FeatureID(newID()), testGeometry, nil, testActor)
 	assert.ErrorIs(t, err, shared.ErrNotFound)
 }
+
+func TestFeatureService_RejectsWritesOnClosedIncident(t *testing.T) {
+	factory, store := testStack(t)
+	incidents, _, layers, features := repos(store)
+	incidentSvc := factory.IncidentService(incidents, layers)
+	featureSvc := factory.FeatureService(features, incidents, layers)
+
+	res, err := incidentSvc.CreateIncident(ctx(), "Closed", nil, nil, []string{"Lage"}, testActor)
+	require.NoError(t, err)
+	featureID := shared.FeatureID(newID())
+	err = featureSvc.PlaceFeature(ctx(), featureID, res.IncidentID, res.LayerIDs[0], testGeometry, testProperties, testActor)
+	require.NoError(t, err)
+	_, err = incidentSvc.CloseIncident(ctx(), res.IncidentID, testActor)
+	require.NoError(t, err)
+
+	_, err = featureSvc.ModifyFeature(ctx(), featureID, testGeometry, nil, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+	err = featureSvc.RemoveFeature(ctx(), featureID, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+}

--- a/internal/core/service/layer.go
+++ b/internal/core/service/layer.go
@@ -58,18 +58,14 @@ func (s *LayerService) CreateLayer(
 	layerID := shared.LayerID(s.ids.New())
 	at := s.clock.Now()
 	err := s.tx.WithinTx(ctx, func(ctx context.Context) error {
-		inc, err := s.incidents.Load(ctx, incidentID)
-		if err != nil {
+		if err := s.requireIncidentOpen(ctx, incidentID); err != nil {
 			return err
-		}
-		if !inc.IsOpen() {
-			return shared.ErrIncidentNotOpen
 		}
 		l := layer.New(layerID)
 		if err := l.Create(incidentID, name, actor.Sub, at); err != nil {
 			return err
 		}
-		_, err = s.repo.Save(ctx, l)
+		_, err := s.repo.Save(ctx, l)
 		return err
 	})
 	if err != nil {
@@ -93,6 +89,9 @@ func (s *LayerService) RenameLayer(ctx context.Context, id shared.LayerID, name 
 	err := s.tx.WithinTx(ctx, func(ctx context.Context) error {
 		l, err := s.repo.Load(ctx, id)
 		if err != nil {
+			return err
+		}
+		if err := s.requireIncidentOpen(ctx, l.IncidentID()); err != nil {
 			return err
 		}
 		if err := l.Rename(name, actor.Sub, at); err != nil {
@@ -123,6 +122,9 @@ func (s *LayerService) RemoveLayer(ctx context.Context, id shared.LayerID, actor
 		if err != nil {
 			return err
 		}
+		if err := s.requireIncidentOpen(ctx, l.IncidentID()); err != nil {
+			return err
+		}
 		if err := l.Remove(shared.DeleteReasonManual, actor.Sub, at); err != nil {
 			return err
 		}
@@ -135,5 +137,16 @@ func (s *LayerService) RemoveLayer(ctx context.Context, id shared.LayerID, actor
 		return err
 	}
 	_ = s.notifier.Notify(ctx)
+	return nil
+}
+
+func (s *LayerService) requireIncidentOpen(ctx context.Context, incidentID shared.IncidentID) error {
+	inc, err := s.incidents.Load(ctx, incidentID)
+	if err != nil {
+		return err
+	}
+	if !inc.IsOpen() {
+		return shared.ErrIncidentNotOpen
+	}
 	return nil
 }

--- a/internal/core/service/layer_test.go
+++ b/internal/core/service/layer_test.go
@@ -48,3 +48,22 @@ func TestLayerService_Remove(t *testing.T) {
 		assert.ErrorIs(t, err, shared.ErrNotFound)
 	})
 }
+
+func TestLayerService_RejectsWritesOnClosedIncident(t *testing.T) {
+	factory, store := testStack(t)
+	incidents, _, layers, _ := repos(store)
+	incidentSvc := factory.IncidentService(incidents, layers)
+	layerSvc := factory.LayerService(layers, incidents)
+
+	res, err := incidentSvc.CreateIncident(ctx(), "Closed", nil, nil, nil, testActor)
+	require.NoError(t, err)
+	layerID, err := layerSvc.CreateLayer(ctx(), res.IncidentID, "Kräfte", testActor)
+	require.NoError(t, err)
+	_, err = incidentSvc.CloseIncident(ctx(), res.IncidentID, testActor)
+	require.NoError(t, err)
+
+	err = layerSvc.RenameLayer(ctx(), layerID, "Umbenannt", testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+	err = layerSvc.RemoveLayer(ctx(), layerID, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+}

--- a/internal/core/service/message.go
+++ b/internal/core/service/message.go
@@ -68,14 +68,8 @@ func (s *MessageService) RecordMessage(
 	var state inbound.MessageState
 
 	err := s.tx.WithinTx(ctx, func(ctx context.Context) error {
-		// Cross-aggregate precondition: incident must be open. Load from aggregate,
-		// not from a projection, to avoid stale-read bugs.
-		inc, err := s.incidents.Load(ctx, incidentID)
-		if err != nil {
+		if err := s.requireIncidentOpen(ctx, incidentID); err != nil {
 			return err
-		}
-		if !inc.IsOpen() {
-			return shared.ErrIncidentNotOpen
 		}
 
 		number, err := s.counter.Next(ctx, incidentID)
@@ -127,6 +121,9 @@ func (s *MessageService) CorrectMessage(
 		if err != nil {
 			return err
 		}
+		if err := s.requireIncidentOpen(ctx, msg.IncidentID()); err != nil {
+			return err
+		}
 		if err := msg.Correct(content, sender, senderDetail, receiver, receiverDetail,
 			medium, msgTime, actor.Sub, at, actor.Sub); err != nil {
 			return err
@@ -168,11 +165,14 @@ func (s *MessageService) TriageMessage(
 		if err != nil {
 			return err
 		}
+		inc, err := s.incidents.Load(ctx, msg.IncidentID())
+		if err != nil {
+			return err
+		}
+		if !inc.IsOpen() {
+			return shared.ErrIncidentNotOpen
+		}
 		if len(divisionIDs) > 0 {
-			inc, err := s.incidents.Load(ctx, msg.IncidentID())
-			if err != nil {
-				return err
-			}
 			for _, divID := range divisionIDs {
 				if _, ok := inc.Division(divID); !ok {
 					return shared.ValidationError{Field: "divisionId", Message: "division does not belong to this incident"}
@@ -211,6 +211,9 @@ func (s *MessageService) DeleteMessage(ctx context.Context, id shared.MessageID,
 		if err != nil {
 			return err
 		}
+		if err := s.requireIncidentOpen(ctx, msg.IncidentID()); err != nil {
+			return err
+		}
 		if err := msg.Delete(shared.DeleteReasonManual, actor.Sub, at); err != nil {
 			return err
 		}
@@ -224,6 +227,17 @@ func (s *MessageService) DeleteMessage(ctx context.Context, id shared.MessageID,
 		return err
 	}
 	_ = s.notifier.Notify(ctx)
+	return nil
+}
+
+func (s *MessageService) requireIncidentOpen(ctx context.Context, incidentID shared.IncidentID) error {
+	inc, err := s.incidents.Load(ctx, incidentID)
+	if err != nil {
+		return err
+	}
+	if !inc.IsOpen() {
+		return shared.ErrIncidentNotOpen
+	}
 	return nil
 }
 

--- a/internal/core/service/message_test.go
+++ b/internal/core/service/message_test.go
@@ -115,6 +115,29 @@ func TestMessageService_DeleteMessage(t *testing.T) {
 	})
 }
 
+func TestMessageService_RejectsWritesOnClosedIncident(t *testing.T) {
+	factory, store := testStack(t)
+	incidents, messages, layers, _ := repos(store)
+	incidentSvc := factory.IncidentService(incidents, layers)
+	messageSvc := factory.MessageService(messages, incidents)
+
+	res, err := incidentSvc.CreateIncident(ctx(), "Closed", nil, nil, nil, testActor)
+	require.NoError(t, err)
+	msg, err := messageSvc.RecordMessage(ctx(), res.IncidentID,
+		"Original", "Sender", "", "Receiver", "", shared.MediumRadio, nil, testActor)
+	require.NoError(t, err)
+	_, err = incidentSvc.CloseIncident(ctx(), res.IncidentID, testActor)
+	require.NoError(t, err)
+
+	content := "Corrected"
+	_, err = messageSvc.CorrectMessage(ctx(), msg.ID, &content, nil, nil, nil, nil, nil, nil, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+	_, err = messageSvc.TriageMessage(ctx(), msg.ID, shared.TriageDone, shared.PriorityHigh, nil, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+	err = messageSvc.DeleteMessage(ctx(), msg.ID, testActor)
+	assert.ErrorIs(t, err, shared.ErrIncidentNotOpen)
+}
+
 func TestMessageService_CounterIsPerIncident(t *testing.T) {
 	factory, store := testStack(t)
 	incidents, messages, layers, _ := repos(store)

--- a/internal/core/service/message_test.go
+++ b/internal/core/service/message_test.go
@@ -25,7 +25,7 @@ func TestMessageService_RecordMessage(t *testing.T) {
 		assert.NotEqual(t, s1.ID, shared.MessageID{})
 
 		s2, err := messageSvc.RecordMessage(ctx(), res.IncidentID,
-			"Lage stabil", "Beobachter Süd", "", "Führungsstab", "", shared.MediumPhone, nil, testActor)
+			"Lage stabil", "Beobachter Süd", "555-1111", "Führungsstab", "555-2222", shared.MediumPhone, nil, testActor)
 		require.NoError(t, err)
 
 		// IDs must differ
@@ -83,7 +83,7 @@ func TestMessageService_TriageMessage(t *testing.T) {
 
 	res, _ := incidentSvc.CreateIncident(ctx(), "Lagebesprechung", nil, nil, nil, testActor)
 	ms, err := messageSvc.RecordMessage(ctx(), res.IncidentID,
-		"Status Update", "Koordinator", "", "Führung", "", shared.MediumPhone, nil, testActor)
+		"Status Update", "Koordinator", "555-1111", "Führung", "555-2222", shared.MediumPhone, nil, testActor)
 	require.NoError(t, err)
 
 	_, err = messageSvc.TriageMessage(ctx(), ms.ID, shared.TriageDone, shared.PriorityHigh, nil, testActor)

--- a/ui/src/api/message/commands.ts
+++ b/ui/src/api/message/commands.ts
@@ -1,5 +1,5 @@
 import { useMutation } from "@apollo/client/react";
-import { Medium, PriorityStatus, TriageStatus } from "types";
+import { Medium, PriorityStatus, TriageStatus, type Division } from "types";
 import { apiErrorFromApolloError } from "../errors";
 import type { CommandHook, CommandState } from "../result";
 import { CREATE_MESSAGE, GET_INCIDENT_MESSAGES, TRIAGE_MESSAGE, UPDATE_MESSAGE } from "./documents";
@@ -25,6 +25,7 @@ export interface TriageMessageArgs {
   priority: PriorityStatus;
   triage: TriageStatus;
   divisionIds: string[];
+  divisions: Division[];
 }
 
 export function useCreateMessage(): CommandHook<CreateMessageArgs> {
@@ -114,6 +115,14 @@ export function useTriageMessage(): CommandHook<TriageMessageArgs> {
         priority: args.priority,
         triage: args.triage,
         divisionIds: args.divisionIds,
+      },
+      optimisticResponse: {
+        triageMessage: {
+          id: args.messageId,
+          triage: args.triage,
+          priority: args.triage === TriageStatus.MoreInfo ? PriorityStatus.Normal : args.priority,
+          divisions: args.divisions,
+        },
       },
       update(cache, { data }) {
         if (!data?.triageMessage) return;

--- a/ui/src/i18n/locales/de/translations.json
+++ b/ui/src/i18n/locales/de/translations.json
@@ -86,6 +86,7 @@
   "messageFlow": "Meldefluss",
   "messageSheet": "Meldezettel",
   "messageTriageTitle": "Triage der Nachricht",
+  "messageTimeTooFarInFuture": "Die Nachrichtenzeit darf nicht mehr als fünf Minuten in der Zukunft liegen.",
   "name": "Name",
   "incidentName": "Ereignisname",
   "open": "öffnen",

--- a/ui/src/i18n/locales/de/translations.json
+++ b/ui/src/i18n/locales/de/translations.json
@@ -30,6 +30,7 @@
   "filtered": "gefiltert",
   "hideClosed": "Verstecke geschlossene",
   "hotline": "Hotline Editor",
+  "incidentClosedNoEdits": "Dieses Ereignis ist geschlossen. Bearbeiten ist derzeit nicht möglich.",
   "immediateMeasures": "Sofortmassnahmen",
   "incident": "Ereignis",
   "incidents": "Ereignisse",

--- a/ui/src/i18n/locales/en/translations.json
+++ b/ui/src/i18n/locales/en/translations.json
@@ -30,6 +30,7 @@
   "filtered": "filtered",
   "hideClosed": "hide closed",
   "hotline": "call log editor",
+  "incidentClosedNoEdits": "This incident is closed. Editing is not currently possible.",
   "immediateMeasures": "immediate measures",
   "incident": "incidents",
   "incidents": "incidents",

--- a/ui/src/i18n/locales/en/translations.json
+++ b/ui/src/i18n/locales/en/translations.json
@@ -86,6 +86,7 @@
   "messageFlow": "reporting flow",
   "messageSheet": "message sheet",
   "messageTriageTitle": "message triage",
+  "messageTimeTooFarInFuture": "Message time cannot be more than five minutes in the future.",
   "name": "name",
   "incidentName": "incident name",
   "open": "open",

--- a/ui/src/i18n/locales/fr/translations.json
+++ b/ui/src/i18n/locales/fr/translations.json
@@ -86,6 +86,7 @@
   "messageFlow": "Liste de distribution",
   "messageSheet": "formulaire de message",
   "messageTriageTitle": "trier le message",
+  "messageTimeTooFarInFuture": "L'heure du message ne peut pas être à plus de cinq minutes dans le futur.",
   "name": "nom",
   "incidentName": "Nom de l'événement",
   "open": "ouvert",

--- a/ui/src/i18n/locales/fr/translations.json
+++ b/ui/src/i18n/locales/fr/translations.json
@@ -30,6 +30,7 @@
   "filtered": "filtré",
   "hideClosed": "masquer fermé",
   "hotline": "Éditeur de la ligne directe",
+  "incidentClosedNoEdits": "Cet événement est fermé. Les modifications ne sont actuellement pas possibles.",
   "immediateMeasures": "mesures immédiates",
   "incident": "Événement",
   "incidents": "Événements",

--- a/ui/src/i18n/locales/it/translations.json
+++ b/ui/src/i18n/locales/it/translations.json
@@ -30,6 +30,7 @@
   "filtered": "filtrato",
   "hideClosed": "nascondi chiuso",
   "hotline": "editore della linea diretta",
+  "incidentClosedNoEdits": "Questo incidente è chiuso. Al momento non è possibile apportare modifiche.",
   "immediateMeasures": "misure immediate",
   "incident": "incidente",
   "incidents": "incidenti",

--- a/ui/src/i18n/locales/it/translations.json
+++ b/ui/src/i18n/locales/it/translations.json
@@ -86,6 +86,7 @@
   "messageFlow": "flusso di segnalazione",
   "messageSheet": "Modulo di registrazione",
   "messageTriageTitle": "valuta il messaggio",
+  "messageTimeTooFarInFuture": "L'orario del messaggio non può essere più di cinque minuti nel futuro.",
   "name": "nome",
   "incidentName": "nome di incidente",
   "open": "aprire",

--- a/ui/src/views/incident/New.tsx
+++ b/ui/src/views/incident/New.tsx
@@ -57,6 +57,8 @@ function IncidentForm(props: { incident: Incident | undefined }) {
   const [updateIncident, updateState] = useUpdateIncident();
 
   const handleSave = async () => {
+    if (name.trim() === "") return;
+
     if (incident) {
       try {
         await updateIncident({
@@ -218,6 +220,7 @@ function IncidentForm(props: { incident: Incident | undefined }) {
                 className="button is-primary is-small is-justified is-rounded is-capitalized"
                 onClick={(e) => {
                   e.preventDefault();
+                  if (assignmentName.trim() === "" || assignmentDescription.trim() === "") return;
                   setAssignments(
                     unionBy(
                       assignments,
@@ -228,7 +231,7 @@ function IncidentForm(props: { incident: Incident | undefined }) {
                   setAssignmentName("");
                   setAssignmentDescription("");
                 }}
-                disabled={assignmentName === "" || assignmentDescription === ""}
+                disabled={assignmentName.trim() === "" || assignmentDescription.trim() === ""}
               >
                 {t("add")}
               </button>
@@ -242,6 +245,7 @@ function IncidentForm(props: { incident: Incident | undefined }) {
             type="submit"
             className="button is-primary is-rounded is-capitalized"
             onClick={() => void handleSave()}
+            disabled={name.trim() === ""}
           >
             {t("save")}
           </button>

--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -39,6 +39,7 @@ function Editor() {
   const [updateMessage, updateState] = useUpdateMessage();
   const [state, dispatch] = useReducer(editorReducer, initEditorState());
   const savingRef = useRef(false);
+  const incidentIsClosed = incident?.closedAt != null;
 
   const isDirty =
     state.content !== "" ||
@@ -164,13 +165,13 @@ function Editor() {
               </div>
             )}
             {saveError && <Notification type="error">{saveError.message}</Notification>}
-            <InputBox />
+            {!incidentIsClosed && <InputBox />}
           </div>
           <div className="column is-half">
             <List
-              showControls={true}
-              setEditorMessage={setEditorMessage}
-              setTriageMessage={setTriageMessage}
+              showControls={!incidentIsClosed}
+              setEditorMessage={incidentIsClosed ? undefined : setEditorMessage}
+              setTriageMessage={incidentIsClosed ? undefined : setTriageMessage}
             />
           </div>
           <TriageModal

--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -16,6 +16,7 @@ import {
   EditorContext,
   type EditorContextValue,
   type MediaDetail,
+  canSave,
   editorReducer,
   initEditorState,
   isNonEmptyString,
@@ -75,6 +76,7 @@ function Editor() {
 
   const handleSave = useCallback(async () => {
     if (!incidentId) return;
+    if (!canSave(state)) return;
     if (savingRef.current) return;
     savingRef.current = true;
     const time = state.time ?? new Date();

--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -3,6 +3,7 @@ import uniq from "lodash/uniq";
 import React, { useCallback, useContext, useId, useMemo, useReducer, useRef } from "react";
 import { Navigate, useBlocker, useNavigate, useParams } from "react-router";
 import { Medium, type Message, PriorityStatus, TriageStatus } from "types";
+import { Spinner } from "components";
 import Notification from "utils/Notification";
 import useDebounce from "utils/useDebounce";
 import { useCreateMessage, useIncidentMessages, useUpdateMessage } from "api";
@@ -132,6 +133,9 @@ function Editor() {
   if (loadedForId === incidentId && incident === null) {
     return <Navigate to="/incident/list" replace />;
   }
+  if (loadedForId !== incidentId) {
+    return <Spinner />;
+  }
 
   const contextValue: EditorContextValue = {
     state,
@@ -165,7 +169,13 @@ function Editor() {
               </div>
             )}
             {saveError && <Notification type="error">{saveError.message}</Notification>}
-            {!incidentIsClosed && <InputBox />}
+            {incidentIsClosed ? (
+              <output className="notification is-warning is-light">
+                {t("incidentClosedNoEdits")}
+              </output>
+            ) : (
+              <InputBox />
+            )}
           </div>
           <div className="column is-half">
             <List

--- a/ui/src/views/journal/EditorForms/Elements.tsx
+++ b/ui/src/views/journal/EditorForms/Elements.tsx
@@ -7,7 +7,7 @@ import { Hint } from "react-autocomplete-hint";
 import { Medium } from "types";
 import { useDate } from "utils/useDate";
 import { ReactEditor } from "../Markdown";
-import { canSave, useEditorContext } from "../editorState";
+import { canSave, hasValidMessageTime, useEditorContext } from "../editorState";
 
 type NonRadioMedium = Exclude<Medium, Medium.Radio>;
 
@@ -80,25 +80,37 @@ const ContentInput = ({ id }: { id: string }) => {
 };
 
 const TimeInput = ({ id }: { id: string }) => {
+  const { t } = useTranslation();
   const { state, dispatch } = useEditorContext();
   const { now } = useDate();
+  const invalidTime = !hasValidMessageTime(state.time, now);
   return (
-    <div className="control is-expanded has-icons-left is-flex-shrink-1">
-      <input
-        id={id}
-        className="input"
-        value={dayjs(state.time ?? now).format("YYYY-MM-DDTHH:mm")}
-        type="datetime-local"
-        onChange={(e) => {
-          dispatch({
-            type: "set_time",
-            time: e.target.value ? dayjs(e.target.value).toDate() : undefined,
-          });
-        }}
-      />
-      <span className="icon is-small is-left">
-        <FontAwesomeIcon icon={faClock} />
-      </span>
+    <div>
+      <div className="control is-expanded has-icons-left is-flex-shrink-1">
+        <input
+          id={id}
+          className="input"
+          value={dayjs(state.time ?? now).format("YYYY-MM-DDTHH:mm")}
+          type="datetime-local"
+          max={dayjs(now).add(5, "minute").format("YYYY-MM-DDTHH:mm")}
+          aria-invalid={invalidTime}
+          aria-describedby={invalidTime ? `${id}-error` : undefined}
+          onChange={(e) => {
+            dispatch({
+              type: "set_time",
+              time: e.target.value ? dayjs(e.target.value).toDate() : undefined,
+            });
+          }}
+        />
+        <span className="icon is-small is-left">
+          <FontAwesomeIcon icon={faClock} />
+        </span>
+      </div>
+      {invalidTime && (
+        <p id={`${id}-error`} className="help is-danger" role="alert">
+          {t("messageTimeTooFarInFuture")}
+        </p>
+      )}
     </div>
   );
 };

--- a/ui/src/views/journal/TriageModal.tsx
+++ b/ui/src/views/journal/TriageModal.tsx
@@ -92,7 +92,7 @@ function TriageForm(props: {
       await triageMessage({
         incidentId,
         messageId: message.id,
-        priority,
+        priority: triage === TriageStatus.MoreInfo ? PriorityStatus.Normal : priority,
         triage,
         divisionIds: assignments.map((d) => d.id),
       });

--- a/ui/src/views/journal/TriageModal.tsx
+++ b/ui/src/views/journal/TriageModal.tsx
@@ -85,6 +85,11 @@ function TriageForm(props: {
   const [assignments, setAssignments] = useState<Division[]>(
     data.message.divisions.map((d) => d.division),
   );
+  const previewMessage: Message = {
+    ...message,
+    priorityId: priority,
+    divisions: assignments.map((division) => ({ division })),
+  };
 
   const handleSave = async (triage: TriageStatus) => {
     if (!incidentId) return;
@@ -95,6 +100,7 @@ function TriageForm(props: {
         priority: triage === TriageStatus.MoreInfo ? PriorityStatus.Normal : priority,
         triage,
         divisionIds: assignments.map((d) => d.id),
+        divisions: assignments,
       });
       setMessage(undefined);
     } catch {
@@ -112,7 +118,7 @@ function TriageForm(props: {
           <JournalMessage
             showControls={false}
             id={message.id}
-            message={message}
+            message={previewMessage}
             divisions={assignments}
             setEditorMessage={undefined}
             setTriageMessage={undefined}
@@ -162,7 +168,7 @@ function TriageForm(props: {
                 <h3 className="title is-size-5">{t("assignPriority")}</h3>
                 <div className="select is-rounded is-small">
                   <select
-                    defaultValue={message.priorityId}
+                    value={priority}
                     onChange={(e) => {
                       e.preventDefault();
                       const prio = Object.values(PriorityStatus).find((p) => p === e.target.value);

--- a/ui/src/views/journal/editorState.test.ts
+++ b/ui/src/views/journal/editorState.test.ts
@@ -190,6 +190,55 @@ describe("canSave", () => {
       false,
     );
   });
+  it("requires details for Phone and Email messages", () => {
+    expect(
+      canSave({
+        ...initEditorState(),
+        media: Medium.Phone,
+        sender: "a",
+        receiver: "b",
+        content: "c",
+      }),
+    ).toBe(false);
+    expect(
+      canSave({
+        ...initEditorState(),
+        media: Medium.Email,
+        sender: "a",
+        senderDetail: "sender@example.test",
+        receiver: "b",
+        receiverDetail: " \t",
+        content: "c",
+      }),
+    ).toBe(false);
+  });
+  it("allows details to remain empty for Radio and Other messages", () => {
+    expect(
+      canSave({
+        ...initEditorState(),
+        media: Medium.Radio,
+        sender: "a",
+        receiver: "b",
+        content: "c",
+      }),
+    ).toBe(true);
+    expect(
+      canSave({
+        ...initEditorState(),
+        media: Medium.Other,
+        sender: "a",
+        receiver: "b",
+        content: "c",
+      }),
+    ).toBe(true);
+  });
+  it("allows timestamps up to five minutes in the future", () => {
+    const now = new Date("2026-09-02T10:00:00Z");
+    const state = { ...initEditorState(), sender: "a", receiver: "b", content: "c" };
+
+    expect(canSave({ ...state, time: new Date("2026-09-02T10:05:00Z") }, now)).toBe(true);
+    expect(canSave({ ...state, time: new Date("2026-09-02T10:05:01Z") }, now)).toBe(false);
+  });
   it("returns true when all three are non-empty", () => {
     expect(canSave({ ...initEditorState(), sender: "a", receiver: "b", content: "c" })).toBe(true);
   });

--- a/ui/src/views/journal/editorState.ts
+++ b/ui/src/views/journal/editorState.ts
@@ -93,8 +93,21 @@ export function isNonEmptyString(v: string | null | undefined): v is string {
   return typeof v === "string" && v.length > 0;
 }
 
-export function canSave(state: EditorState): boolean {
-  return state.content.trim() !== "" && state.sender.trim() !== "" && state.receiver.trim() !== "";
+export function hasValidMessageTime(time: Date | undefined, now = new Date()): boolean {
+  return time === undefined || time.getTime() <= now.getTime() + 5 * 60 * 1000;
+}
+
+export function canSave(state: EditorState, now = new Date()): boolean {
+  if (state.content.trim() === "" || state.sender.trim() === "" || state.receiver.trim() === "") {
+    return false;
+  }
+  if (!hasValidMessageTime(state.time, now)) {
+    return false;
+  }
+  if (state.media === Medium.Phone || state.media === Medium.Email) {
+    return state.senderDetail.trim() !== "" && state.receiverDetail.trim() !== "";
+  }
+  return true;
 }
 
 export function buildMessageVars(

--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -152,6 +152,10 @@ function MapView() {
 
 function Layers() {
   const { state } = useContext(LayerContext);
+  const {
+    state: { incident },
+  } = useContext(IncidentContext);
+  const activeLayer = incident?.closedAt != null ? undefined : state.activeLayer;
 
   return (
     <>
@@ -161,14 +165,14 @@ function Layers() {
       </div>
 
       {/* Active Layer */}
-      <ActiveLayer />
+      {activeLayer !== undefined && <ActiveLayer />}
       <BabsIconController />
 
       {/* Inactive Layers */}
       <InactiveLayers
         layers={
           state.layers
-            .filter((l) => l.layer?.id !== state.activeLayer)
+            .filter((l) => l.layer?.id !== activeLayer)
             .filter((l) => l.isVisible)
             .map((l) => l.layer) || []
         }
@@ -345,6 +349,9 @@ function ActiveLayer() {
 
 function Draw() {
   const { state, dispatch } = useContext(LayerContext);
+  const {
+    state: { incident },
+  } = useContext(IncidentContext);
   const { incidentId } = useParams();
   const { current: map } = useMap();
 
@@ -497,7 +504,7 @@ function Draw() {
     }
   }, [state.draw, map?.loaded, state.selectedFeature]);
 
-  if (state.activeLayer === undefined) {
+  if (incident?.closedAt != null || state.activeLayer === undefined) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Improves input validation, closed-incident protections, journal triage behavior, and CLI configuration handling.

- Reject whitespace-only required incident, division, and journal-message fields.
- Require sender and receiver details for Phone and Email messages.
- Reject message timestamps more than five minutes ahead of the server clock, with localized UI feedback.
- Ensure “Needs more information” always resets priority to Normal, including during read-model replay.
- Prevent message, layer, and feature writes when the owning incident is closed; hide unavailable journal/map editing controls.
- Improve journal UX with immediate optimistic triage updates, live triage preview updates, and a localized closed-incident read-only notice.
- Improve Cobra/Viper wiring with explicit config-file support, typed command configuration, hyphenated YAML keys matching flags, environment-variable documentation, and command-specific flag scope.

## Read-Model Impact

The message projector normalizes historic `MOREINFO` + `HIGH` events to `MOREINFO` + `NORMAL` during replay and bumps its version, so deployment triggers a read-model rebuild.