### PR TITLE
fix(retention): base auto-close on updated time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,6 +465,7 @@ are preserved. Never edit the generated `generated/` package by hand.
 Migrations live in `migrations/`. Use goose conventions:
 
 - SQL: `NNNN_<slug>.sql` with `-- +goose Up` / `-- +goose Down` annotations.
+- Never change past migration files that may already be committed or applied; add a new migration instead. Only edit migration files that are still uncommitted and not yet applied anywhere.
 - Go: register in `migrations/migrations.go` via `goose.NewGoMigration`; always set `m.Source`
   to the filename so the migration appears correctly in goose output:
   ```go

--- a/docs/development/Incident Retention.md
+++ b/docs/development/Incident Retention.md
@@ -75,7 +75,7 @@ migration, then restart the server or wait for a standby projector to become lea
 
 | Flag | YAML key | Default | Environment variable | Meaning |
 | --- | --- | --- | --- | --- |
-| `auto-close-incidents` | `auto-close-incidents` | `0` | `SITREP_AUTO_CLOSE_INCIDENTS` | Days after creation before an open incident is automatically closed. |
+| `auto-close-incidents` | `auto-close-incidents` | `0` | `SITREP_AUTO_CLOSE_INCIDENTS` | Days after the open incident was last updated before it is automatically closed. |
 | `auto-archive-incidents` | `auto-archive-incidents` | `0` | `SITREP_AUTO_ARCHIVE_INCIDENTS` | Days after closure before a closed, non-deleted incident is archived. |
 
 Both settings are `uint` day counts and are local to `sitrep serve`. A value of `0` disables the
@@ -106,7 +106,7 @@ per-incident message counter after the archive copies are recorded in the same t
 
 ### Lifecycle
 
-Open incidents past `auto-close-incidents` receive a normal `Closed{ReasonAutoTimeout}` event.
+Open incidents past `auto-close-incidents` receive a normal `Closed{ReasonAutoTimeout}` event. The clock uses the incident read model's `updated_at` timestamp, so reopening an incident resets the wait period.
 Closed incidents past `auto-archive-incidents` receive `Deleted{ReasonPurge}` before their streams
 are archived. A manually deleted incident already has `Deleted{ReasonManual}`, so it is archived
 directly after its fixed seven-day delay without appending a second delete event.

--- a/internal/adapter/outbound/eventstore/postgres/retention.go
+++ b/internal/adapter/outbound/eventstore/postgres/retention.go
@@ -28,8 +28,8 @@ func NewIncidentRetention(pool *pgxpool.Pool) *IncidentRetention {
 func (r *IncidentRetention) OpenBefore(ctx context.Context, before time.Time, limit int) ([]shared.IncidentID, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT id FROM rm_incident
-		WHERE is_closed = false AND is_deleted = false AND created_at <= $1
-		ORDER BY created_at
+		WHERE is_closed = false AND is_deleted = false AND updated_at <= $1
+		ORDER BY updated_at
 		LIMIT $2`, before, limit)
 	return scanIncidentIDs(rows, err)
 }


### PR DESCRIPTION
## Summary
- select auto-close candidates by `rm_incident.updated_at` instead of `created_at`
- document that reopening an incident resets the auto-close wait period
- add an agent guideline to avoid editing past migration files

## Validation
- `golangci-lint run ./internal/adapter/outbound/eventstore/postgres ./internal/adapter/outbound/eventstore/postgres/projection`
- `go test ./...`