### PR TITLE
feat(projection): trace projector work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,9 +328,23 @@ When you add a new service method, follow the pattern above. When you add a new 
 performs I/O (HTTP call, SQL query), check whether an OTel contrib library already instruments it
 before adding manual spans.
 
+### Traces — projector
+
+All projector implementations use `otel.Tracer("sitrep/projector")`. Keep spans around finite
+units of work: lock-acquire attempts, checkpoint initialization, catch-up, handler reset/rebuild,
+retention, and per-event apply. Do not wrap long-lived `Run` loops or leadership periods in spans;
+the `projector.running` gauge covers lifecycle. Attach stable attributes such as handler name,
+lock name, stream type, event type, stream ID, event version, and applied-event counts. Record
+errors and set span status before returning them, but treat `context.Canceled` during shutdown as
+a normal lifecycle outcome rather than a span error.
+
+The Postgres projector relies on `NOTIFY` rather than periodic polling. Its notifier keeps a
+persistent `LISTEN` connection while the projector is running so notifications can queue while a
+catch-up pass is applying events.
+
 ### Metrics — projector
 
-The Postgres projector exposes four counters/histograms registered via `otel.Meter`:
+The projectors expose counters, histograms, and gauges registered via `otel.Meter`:
 
 | Metric name                  | Type      | Attributes                        |
 | ---------------------------- | --------- | --------------------------------- |
@@ -338,6 +352,9 @@ The Postgres projector exposes four counters/histograms registered via `otel.Met
 | `projector.catchup.duration` | histogram | —                                 |
 | `projector.errors`           | counter   | `handler`, `type` (checkpoint/read/apply) |
 | `projector.dead_letters`     | counter   | `handler`                         |
+| `projector.leadership.acquired` | counter | —                                 |
+| `projector.lock.contended`   | counter   | —                                 |
+| `projector.running`          | gauge     | `backend`                         |
 
 When adding metrics elsewhere, obtain a meter with a package-scoped name:
 

--- a/internal/adapter/outbound/eventstore/inmem/projection/projector.go
+++ b/internal/adapter/outbound/eventstore/inmem/projection/projector.go
@@ -7,10 +7,24 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/f-eld-ch/sitrep/internal/core/port/outbound"
+	"github.com/f-eld-ch/sitrep/internal/eventsourcing"
 )
 
 const batchSize = 100
+
+func recordSpanError(span trace.Span, err error) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
 
 // Projector reads the global event stream from the in-memory store and applies
 // handlers synchronously. It is designed for test use:
@@ -27,6 +41,7 @@ type Projector struct {
 	handlers []Handler
 	cursors  map[string]outbound.Cursor
 	log      *slog.Logger
+	tracer   trace.Tracer
 }
 
 func NewProjector(store outbound.EventStore, handlers []Handler) *Projector {
@@ -39,6 +54,7 @@ func NewProjector(store outbound.EventStore, handlers []Handler) *Projector {
 		handlers: handlers,
 		cursors:  cursors,
 		log:      slog.Default().WithGroup("inmem-projector"),
+		tracer:   otel.Tracer("sitrep/projector"),
 	}
 }
 
@@ -51,9 +67,18 @@ func (p *Projector) WithNotifier(n outbound.EventNotifier) *Projector {
 
 // CatchUp reads all events appended since each handler's last cursor and applies
 // them. It processes handlers in registration order and returns on the first error.
-func (p *Projector) CatchUp(ctx context.Context) error {
+func (p *Projector) CatchUp(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "InmemProjector.CatchUp",
+		trace.WithAttributes(attribute.Int("projector.handlers", len(p.handlers))))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	var totalApplied int
 	for _, h := range p.handlers {
 		cursor := p.cursors[h.Name()]
+		handlerApplied := 0
 		for {
 			events, next, err := p.store.Read(ctx, cursor, batchSize)
 			if err != nil {
@@ -66,10 +91,11 @@ func (p *Projector) CatchUp(ctx context.Context) error {
 				if !h.Handles(e.StreamType, e.EventType) {
 					continue
 				}
-				if err := h.Apply(ctx, e); err != nil {
+				if err := p.applyEvent(ctx, h, e); err != nil {
 					return fmt.Errorf("inmem projector %s apply %s/%s v%d: %w",
 						h.Name(), e.StreamType, e.EventType, e.Version, err)
 				}
+				handlerApplied++
 			}
 			p.cursors[h.Name()] = next
 			cursor = next
@@ -77,13 +103,39 @@ func (p *Projector) CatchUp(ctx context.Context) error {
 				break
 			}
 		}
+		totalApplied += handlerApplied
 	}
+	span.SetAttributes(attribute.Int("projector.events.applied", totalApplied))
 	return nil
+}
+
+func (p *Projector) applyEvent(ctx context.Context, h Handler, e eventsourcing.Event) (err error) {
+	ctx, span := p.tracer.Start(ctx, "InmemProjector.ApplyEvent",
+		trace.WithAttributes(
+			attribute.String("projector.handler", h.Name()),
+			attribute.String("event.stream_type", e.StreamType),
+			attribute.String("event.stream_id", e.StreamID.String()),
+			attribute.String("event.type", e.EventType),
+			attribute.Int("event.version", e.Version),
+		))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	return h.Apply(ctx, e)
 }
 
 // Reset rebuilds all handlers from the beginning of the event log. Useful when a
 // handler's Version() changes or when tests need a clean read-model mid-run.
-func (p *Projector) Reset(ctx context.Context) error {
+func (p *Projector) Reset(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "InmemProjector.Reset",
+		trace.WithAttributes(attribute.Int("projector.handlers", len(p.handlers))))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	for _, h := range p.handlers {
 		if err := h.Reset(ctx); err != nil {
 			return fmt.Errorf("inmem projector reset %s: %w", h.Name(), err)

--- a/internal/adapter/outbound/eventstore/postgres/eventstore.go
+++ b/internal/adapter/outbound/eventstore/postgres/eventstore.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -230,6 +231,8 @@ func TxFromCtx(ctx context.Context) (pgx.Tx, error) {
 type Notifier struct {
 	pool    *pgxpool.Pool
 	channel string
+	mu      sync.Mutex
+	conn    *pgxpool.Conn
 }
 
 func NewNotifier(pool *pgxpool.Pool, channel string) *Notifier {
@@ -244,17 +247,49 @@ func (n *Notifier) Notify(ctx context.Context) error {
 	return err
 }
 
+func (n *Notifier) EnsureListening(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.ensureListeningLocked(ctx)
+}
+
 func (n *Notifier) Wait(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if err := n.ensureListeningLocked(ctx); err != nil {
+		return err
+	}
+	_, err := n.conn.Conn().WaitForNotification(ctx)
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		n.conn.Release()
+		n.conn = nil
+	}
+	return err
+}
+
+func (n *Notifier) Close() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.conn != nil {
+		n.conn.Release()
+		n.conn = nil
+	}
+}
+
+func (n *Notifier) ensureListeningLocked(ctx context.Context) error {
+	if n.conn != nil {
+		return nil
+	}
 	conn, err := n.pool.Acquire(ctx)
 	if err != nil {
 		return err
 	}
-	defer conn.Release()
-	if _, err = conn.Exec(ctx, fmt.Sprintf("LISTEN %s", n.channel)); err != nil {
+	if _, err := conn.Exec(ctx, fmt.Sprintf("LISTEN %s", n.channel)); err != nil {
+		conn.Release()
 		return err
 	}
-	_, err = conn.Conn().WaitForNotification(ctx)
-	return err
+	n.conn = conn
+	return nil
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/internal/adapter/outbound/eventstore/postgres/projection/projector.go
+++ b/internal/adapter/outbound/eventstore/postgres/projection/projector.go
@@ -5,7 +5,8 @@
 // registration order, and advances the checkpoint.
 //
 // All projections are asynchronous — they run outside the write transaction.
-// NOTIFY wakes the projector on commit; watermark polling guarantees correctness.
+// NOTIFY wakes the projector on commit; a persistent LISTEN connection avoids
+// missing notifications between catch-up passes.
 package projection
 
 import (
@@ -19,7 +20,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/f-eld-ch/sitrep/internal/core/port/outbound"
 	"github.com/f-eld-ch/sitrep/internal/eventsourcing"
@@ -47,6 +50,14 @@ var errProjectionAhead = errors.New("stored projection version is ahead of this 
 // than maxConsecutiveCatchUpFailures times, so the leader releases and a
 // standby can try.
 var errCatchUpStuck = errors.New("projector: too many consecutive catch-up failures")
+
+func recordSpanError(span trace.Span, err error) {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
 
 // Option configures a Projector.
 type Option func(*Projector)
@@ -83,6 +94,10 @@ type noopLock struct{}
 
 func (noopLock) Acquire(_ context.Context, _ string) (func(), error) { return func() {}, nil }
 
+type listenStarter interface {
+	EnsureListening(context.Context) error
+}
+
 // Compile-time assertion: Projector satisfies the outbound.Projector port.
 var _ outbound.Projector = (*Projector)(nil)
 
@@ -111,6 +126,7 @@ type Projector struct {
 	notifier outbound.EventNotifier
 	handlers []Handler
 	log      *slog.Logger
+	tracer   trace.Tracer
 
 	// leader election
 	lock            outbound.ProjectorLock
@@ -168,6 +184,7 @@ func NewProjector(
 		notifier:        notifier,
 		handlers:        handlers,
 		log:             slog.Default().WithGroup("projector"),
+		tracer:          otel.Tracer("sitrep/projector"),
 		lock:            noopLock{},
 		lockName:        DefaultLockName,
 		standbyInterval: defaultStandbyInterval,
@@ -196,7 +213,7 @@ func (p *Projector) Run(ctx context.Context) error {
 	p.log.InfoContext(ctx, "projector starting", "handlers", names)
 
 	for {
-		release, err := p.lock.Acquire(ctx, p.lockName)
+		release, err := p.acquireLock(ctx)
 		switch {
 		case errors.Is(err, outbound.ErrLockHeld):
 			p.lockContended.Add(ctx, 1)
@@ -218,6 +235,18 @@ func (p *Projector) Run(ctx context.Context) error {
 	}
 }
 
+func (p *Projector) acquireLock(ctx context.Context) (release func(), err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.AcquireLock",
+		trace.WithAttributes(attribute.String("projector.lock_name", p.lockName)))
+	defer func() {
+		if err != nil && !errors.Is(err, outbound.ErrLockHeld) {
+			recordSpanError(span, err)
+		}
+		span.End()
+	}()
+	return p.lock.Acquire(ctx, p.lockName)
+}
+
 // lead runs the projection loop while this instance holds the lock. It calls
 // release (via defer) before returning, guaranteeing the lock is freed before
 // pool.Close() in Teardown.
@@ -236,8 +265,12 @@ func (p *Projector) lead(ctx context.Context, release func()) error {
 		return fmt.Errorf("projector: init checkpoints: %w", err)
 	}
 
-	pollTicker := time.NewTicker(500 * time.Millisecond)
-	defer pollTicker.Stop()
+	if starter, ok := p.notifier.(listenStarter); ok {
+		if err := starter.EnsureListening(ctx); err != nil {
+			return fmt.Errorf("projector: start notifier listener: %w", err)
+		}
+	}
+
 	retentionTicker := time.NewTicker(time.Hour)
 	defer retentionTicker.Stop()
 
@@ -275,28 +308,47 @@ func (p *Projector) lead(ctx context.Context, release func()) error {
 			}
 		}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-pollTicker.C:
-		case <-retentionTicker.C:
-			if err := p.runRetentionOnce(ctx); err != nil {
-				return err
-			}
-		// notifier.Wait blocks until a NOTIFY arrives or ctx is cancelled.
-		default:
-			waitCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			_ = p.notifier.Wait(waitCtx)
-			cancel()
+		if err := p.waitForNotificationOrRetention(ctx, retentionTicker.C); err != nil {
+			return err
 		}
 	}
 }
 
-func (p *Projector) runRetentionOnce(ctx context.Context) error {
+func (p *Projector) waitForNotificationOrRetention(ctx context.Context, retentionC <-chan time.Time) error {
+	waitCtx, cancel := context.WithCancel(ctx)
+	waitDone := make(chan error, 1)
+	go func() { waitDone <- p.notifier.Wait(waitCtx) }()
+
+	select {
+	case <-ctx.Done():
+		cancel()
+		<-waitDone
+		return ctx.Err()
+	case <-retentionC:
+		cancel()
+		<-waitDone
+		return p.runRetentionOnce(ctx)
+	case err := <-waitDone:
+		cancel()
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return fmt.Errorf("projector notification wait: %w", err)
+		}
+		return nil
+	}
+}
+
+func (p *Projector) runRetentionOnce(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.RunRetention")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	if p.runRetention == nil {
 		return nil
 	}
 	archived, err := p.runRetention(ctx)
+	span.SetAttributes(attribute.Bool("projector.retention.archived", archived))
 	return handleRetentionResult(archived, err, func() error { return p.rebuildAfterArchive(ctx) })
 }
 
@@ -312,7 +364,14 @@ func handleRetentionResult(archived bool, retentionErr error, rebuild func() err
 	return nil
 }
 
-func (p *Projector) rebuildAfterArchive(ctx context.Context) error {
+func (p *Projector) rebuildAfterArchive(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.RebuildAfterArchive",
+		trace.WithAttributes(attribute.Int("projector.handlers", len(p.handlers))))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	p.log.InfoContext(ctx, "retention archived incidents, rebuilding read models")
 	for _, handler := range p.handlers {
 		if err := p.resetProjection(ctx, handler); err != nil {
@@ -343,7 +402,15 @@ func (p *Projector) sleep(ctx context.Context, d time.Duration) bool {
 }
 
 // catchUp reads all new events from each handler's checkpoint and applies them.
-func (p *Projector) catchUp(ctx context.Context) error {
+func (p *Projector) catchUp(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.CatchUp",
+		trace.WithAttributes(attribute.Int("projector.handlers", len(p.handlers))))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	slog.DebugContext(ctx, "catch-up starting")
 	start := time.Now()
 	var totalApplied int
 	for _, h := range p.handlers {
@@ -368,10 +435,27 @@ func (p *Projector) catchUp(ctx context.Context) error {
 					continue
 				}
 				if err := p.applyWithDeadLetter(ctx, h, e); err != nil {
+					span.RecordError(err,
+						trace.WithAttributes(
+							attribute.String("projector.handler", h.Name()),
+							attribute.String("event.stream_type", e.StreamType),
+							attribute.String("event.stream_id", e.StreamID.String()),
+							attribute.String("event.type", e.EventType),
+							attribute.Int("event.version", e.Version),
+						))
 					p.log.Error("handler failed after retries", "handler", h.Name(), "error", err)
 					p.handlerErrors.Add(ctx, 1, metric.WithAttributes(handlerAttr, attribute.String("type", "apply")))
 					// park the event and continue — the projection is now known-incomplete
 					if parkErr := p.parkDeadLetter(ctx, h.Name(), next, e, err); parkErr != nil {
+						span.RecordError(parkErr,
+							trace.WithAttributes(
+								attribute.String("projector.handler", h.Name()),
+								attribute.String("projector.error_type", "dead_letter"),
+								attribute.String("event.stream_type", e.StreamType),
+								attribute.String("event.stream_id", e.StreamID.String()),
+								attribute.String("event.type", e.EventType),
+								attribute.Int("event.version", e.Version),
+							))
 						p.log.Error("failed to park dead letter", "error", parkErr)
 					} else {
 						p.deadLetters.Add(ctx, 1, metric.WithAttributes(handlerAttr))
@@ -399,6 +483,7 @@ func (p *Projector) catchUp(ctx context.Context) error {
 		p.log.Info("catch-up complete", "total_applied", totalApplied)
 	}
 	p.catchupDur.Record(ctx, time.Since(start).Seconds())
+	span.SetAttributes(attribute.Int("projector.events.applied", totalApplied))
 	return nil
 }
 
@@ -418,7 +503,20 @@ func (p *Projector) applyWithDeadLetter(ctx context.Context, h Handler, e events
 	return lastErr
 }
 
-func (p *Projector) applyInTx(ctx context.Context, h Handler, e eventsourcing.Event) error {
+func (p *Projector) applyInTx(ctx context.Context, h Handler, e eventsourcing.Event) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.ApplyEvent",
+		trace.WithAttributes(
+			attribute.String("projector.handler", h.Name()),
+			attribute.String("event.stream_type", e.StreamType),
+			attribute.String("event.stream_id", e.StreamID.String()),
+			attribute.String("event.type", e.EventType),
+			attribute.Int("event.version", e.Version),
+		))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
 		return err
@@ -449,7 +547,14 @@ func TxFromCtx(ctx context.Context) (interface {
 // Checkpoint management
 // ──────────────────────────────────────────────────────────────────────────────
 
-func (p *Projector) initCheckpoints(ctx context.Context) error {
+func (p *Projector) initCheckpoints(ctx context.Context) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.InitCheckpoints",
+		trace.WithAttributes(attribute.Int("projector.handlers", len(p.handlers))))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	for _, h := range p.handlers {
 		var storedVersion int
 		err := p.pool.QueryRow(ctx,
@@ -488,11 +593,21 @@ func (p *Projector) initCheckpoints(ctx context.Context) error {
 	return nil
 }
 
-func (p *Projector) resetProjection(ctx context.Context, h Handler) error {
+func (p *Projector) resetProjection(ctx context.Context, h Handler) (err error) {
+	ctx, span := p.tracer.Start(ctx, "PostgresProjector.ResetProjection",
+		trace.WithAttributes(
+			attribute.String("projector.handler", h.Name()),
+			attribute.Int("projector.handler_version", h.Version()),
+		))
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	if err := h.Reset(ctx); err != nil {
 		return fmt.Errorf("reset projection %s: %w", h.Name(), err)
 	}
-	_, err := p.pool.Exec(ctx, `
+	_, err = p.pool.Exec(ctx, `
 		DELETE FROM eventsourcing.projection_dead_letter WHERE projection = $1`,
 		h.Name())
 	if err != nil {

--- a/internal/adapter/outbound/eventstore/postgres/projection/projector_notify_test.go
+++ b/internal/adapter/outbound/eventstore/postgres/projection/projector_notify_test.go
@@ -1,0 +1,97 @@
+package projection
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+type blockingNotifier struct {
+	entered chan struct{}
+	release chan error
+}
+
+func newBlockingNotifier() *blockingNotifier {
+	return &blockingNotifier{
+		entered: make(chan struct{}),
+		release: make(chan error, 1),
+	}
+}
+
+func (n *blockingNotifier) Notify(context.Context) error { return nil }
+
+func (n *blockingNotifier) Wait(ctx context.Context) error {
+	select {
+	case <-n.entered:
+	default:
+		close(n.entered)
+	}
+
+	select {
+	case err := <-n.release:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestProjector_WaitForNotificationOrRetentionWaitsForNotify(t *testing.T) {
+	notifier := newBlockingNotifier()
+	p := &Projector{notifier: notifier, tracer: otel.Tracer("sitrep/projector")}
+	retentionC := make(chan time.Time)
+
+	done := make(chan error, 1)
+	go func() { done <- p.waitForNotificationOrRetention(context.Background(), retentionC) }()
+
+	<-notifier.entered
+	select {
+	case err := <-done:
+		t.Fatalf("wait returned before notification: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	notifier.release <- nil
+	require.NoError(t, <-done)
+}
+
+func TestProjector_WaitForNotificationOrRetentionRunsRetention(t *testing.T) {
+	notifier := newBlockingNotifier()
+	retentionC := make(chan time.Time, 1)
+	retentionCalls := 0
+	p := &Projector{
+		notifier: notifier,
+		tracer:   otel.Tracer("sitrep/projector"),
+		runRetention: func(context.Context) (bool, error) {
+			retentionCalls++
+			return false, nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- p.waitForNotificationOrRetention(context.Background(), retentionC) }()
+
+	<-notifier.entered
+	retentionC <- time.Now()
+	require.NoError(t, <-done)
+	assert.Equal(t, 1, retentionCalls)
+}
+
+func TestProjector_WaitForNotificationOrRetentionReturnsNotifierErrors(t *testing.T) {
+	notifier := newBlockingNotifier()
+	p := &Projector{notifier: notifier, tracer: otel.Tracer("sitrep/projector")}
+	wantErr := errors.New("listen failed")
+
+	done := make(chan error, 1)
+	go func() { done <- p.waitForNotificationOrRetention(context.Background(), make(chan time.Time)) }()
+
+	<-notifier.entered
+	notifier.release <- wantErr
+	err := <-done
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}

--- a/internal/adapter/outbound/eventstore/projection/instrument.go
+++ b/internal/adapter/outbound/eventstore/projection/instrument.go
@@ -18,6 +18,7 @@ import (
 // gauge drops to 0 outside of a planned shutdown.
 type InstrumentedProjector struct {
 	inner   outbound.Projector
+	backend string
 	running atomic.Int32
 	reg     metric.Registration
 }
@@ -26,7 +27,10 @@ type InstrumentedProjector struct {
 // gauge ("postgres" or "inmem"). Errors registering the gauge are non-fatal —
 // the projector still runs, just without metrics.
 func NewInstrumentedProjector(inner outbound.Projector, backend string) *InstrumentedProjector {
-	ip := &InstrumentedProjector{inner: inner}
+	ip := &InstrumentedProjector{
+		inner:   inner,
+		backend: backend,
+	}
 
 	meter := otel.Meter("sitrep/projector")
 	gauge, err := meter.Int64ObservableGauge("projector.running",

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -55,7 +55,7 @@ func buildPostgresStack(ctx context.Context, dsn string, autoCloseDays, autoArch
 	}
 	cfg.ConnConfig.Tracer = otelpgx.NewTracer()
 	// The projector leader holds one connection for the advisory lock for its
-	// entire lifetime; Notifier.Wait needs one every ~2s. The pgx default of
+	// entire lifetime; Notifier.Wait keeps one persistent LISTEN connection. The pgx default of
 	// max(4, NumCPU) is too small under concurrent load, so we enforce a floor.
 	if cfg.MaxConns < 8 {
 		cfg.MaxConns = 8
@@ -122,6 +122,7 @@ func buildPostgresStack(ctx context.Context, dsn string, autoCloseDays, autoArch
 			cancelProj()
 			<-projDone
 			proj.Unregister()
+			notifier.Close()
 			pool.Close()
 		},
 	}, nil


### PR DESCRIPTION
## Summary
- add bounded projector trace spans for catch-up, reset/rebuild, retention, lock acquisition, and per-event apply
- avoid long-lived Run/leadership spans and keep lifecycle represented by the running gauge
- remove Postgres projector polling by keeping a persistent LISTEN connection for notification-only wakeups
- add tests for notification wait behavior and retention wakeups

## Validation
- `go test ./internal/adapter/outbound/eventstore/postgres ./internal/adapter/outbound/eventstore/postgres/projection ./internal/cli`
- `golangci-lint fmt ./internal/adapter/outbound/eventstore/postgres ./internal/adapter/outbound/eventstore/postgres/projection ./internal/cli`
- `golangci-lint run ./internal/adapter/outbound/eventstore/postgres ./internal/adapter/outbound/eventstore/postgres/projection ./internal/cli`
- `go test ./...`
- `cd ui && yarn fmt && yarn lint`

Note: `yarn lint` reports an existing warning in `ui/src/views/journal/Editor.tsx` about a `messages` dependency changing every render.