### PR TITLE
fix(ui): stabilize journal autocomplete dependencies

### DIFF
--- a/ui/src/views/journal/Editor.tsx
+++ b/ui/src/views/journal/Editor.tsx
@@ -29,6 +29,8 @@ export type { PhoneDetail, EmailDetail, OtherDetail, RadioDetail } from "./edito
 export { useEditorContext } from "./editorState";
 export { ReactEditor, ReactPreview } from "./Markdown";
 
+const EMPTY_MESSAGES: Message[] = [];
+
 function Editor() {
   const { t } = useTranslation();
   const { incidentId } = useParams();
@@ -54,7 +56,8 @@ function Editor() {
 
   const blocker = useBlocker(isDirty);
 
-  const messages = messagesResult.status === "ready" ? messagesResult.data.messages : [];
+  const messages =
+    messagesResult.status === "ready" ? messagesResult.data.messages : EMPTY_MESSAGES;
 
   const autocompleteDetails = useMemo<AutofillDetail>(
     () => ({


### PR DESCRIPTION
## Summary
- use a stable empty message list fallback in the journal editor
- remove the React hooks exhaustive-deps lint warning caused by a fresh [] dependency

## Validation
- yarn lint
- yarn typecheck
- yarn fmt
- yarn test --run src/views/journal/editorState.test.ts src/views/journal/listUtils.test.ts src/views/journal/Message.test.tsx src/views/journal/EditorForms/FormRow.test.tsx src/views/journal/EditorForms/MediumForm.test.tsx