### PR TITLE
fix(server): improve handling of stale clients to force cache clearning

### DIFF
--- a/server/handlers.go
+++ b/server/handlers.go
@@ -39,10 +39,12 @@ func (s *Server) ready(c *echo.Context) error {
 // the *next* navigation is guaranteed to fetch a current bundle instead of repeating the same
 // broken request against the same stale worker.
 func (s *Server) legacyGraphQLGone(c *echo.Context) error {
-	c.Response().Header().Set("Clear-Site-Data", `"cache", "storage"`)
+	c.Response().Header().Set("Clear-Site-Data", `"cache", "storage", "executionContexts"`)
 	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
 
-	return c.JSON(http.StatusGone, map[string]any{
+	// Chromium ignores Clear-Site-Data on 4xx/5xx responses, so this must be a 2xx to take
+	// effect at all. 200 + an errors array is also just the normal GraphQL error convention.
+	return c.JSON(http.StatusOK, map[string]any{
 		"errors": []map[string]string{
 			{"message": "this API was removed; reload the page to fetch the current version"},
 		},

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -28,3 +28,23 @@ func (s *Server) ready(c *echo.Context) error {
 
 	return c.JSON(http.StatusOK, map[string]string{"status": "ready"})
 }
+
+// legacyGraphQLGone answers requests to the pre-26.9.0 Hasura-proxied GraphQL endpoint,
+// which no longer exists.
+//
+// Without this route the request falls through to the SPA static middleware, which (HTML5
+// fallback) serves index.html with a 200. A pre-26.9.0 client still running from a stale
+// service worker cache then tries to JSON-parse that HTML and fails loudly and confusingly.
+// Clear-Site-Data instructs the browser to drop the cached service worker and its caches, so
+// the *next* navigation is guaranteed to fetch a current bundle instead of repeating the same
+// broken request against the same stale worker.
+func (s *Server) legacyGraphQLGone(c *echo.Context) error {
+	c.Response().Header().Set("Clear-Site-Data", `"cache", "storage"`)
+	c.Response().Header().Set(echo.HeaderCacheControl, "no-store")
+
+	return c.JSON(http.StatusGone, map[string]any{
+		"errors": []map[string]string{
+			{"message": "this API was removed; reload the page to fetch the current version"},
+		},
+	})
+}

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -123,8 +123,8 @@ func TestLegacyGraphQLGone(t *testing.T) {
 			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, nil)
 			s.router.ServeHTTP(rec, req)
 
-			require.Equal(t, http.StatusGone, rec.Code)
-			assert.Equal(t, `"cache", "storage"`, rec.Header().Get("Clear-Site-Data"))
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, `"cache", "storage", "executionContexts"`, rec.Header().Get("Clear-Site-Data"))
 			assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
 
 			var got map[string]any
@@ -136,6 +136,11 @@ func TestLegacyGraphQLGone(t *testing.T) {
 
 // The static SPA fallback must still catch genuinely unknown paths; only the removed
 // legacy endpoint gets the Clear-Site-Data treatment.
+//
+// Doesn't assert the SPA fallback's status code: CI runs this without a real UI build (see
+// build.yaml's placeholder ui/build dir), so index.html is missing there and the static
+// middleware answers 500, whereas a real build answers 200. Either way, this route isn't
+// legacyGraphQLGone, which is the only thing worth asserting here.
 func TestUnrelatedUnmatchedPathStillFallsBackToSPA(t *testing.T) {
 	s := NewServer()
 
@@ -143,7 +148,6 @@ func TestUnrelatedUnmatchedPathStillFallsBackToSPA(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/some/unknown/route", nil)
 	s.router.ServeHTTP(rec, req)
 
-	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Empty(t, rec.Header().Get("Clear-Site-Data"))
 }
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"slices"
 	"syscall"
 	"testing"
 
 	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type rejectingEnforcer struct{}
@@ -26,9 +27,7 @@ func (rejectingEnforcer) CallbackHandler(*echo.Context) error { return nil }
 
 func TestShutdownSignals(t *testing.T) {
 	want := []os.Signal{os.Interrupt, syscall.SIGTERM}
-	if got := shutdownSignals(); !slices.Equal(got, want) {
-		t.Errorf("shutdown signals: got %v, want %v", got, want)
-	}
+	assert.Equal(t, want, shutdownSignals())
 }
 
 func TestAPIV2UsesFinalEnforcer(t *testing.T) {
@@ -40,9 +39,7 @@ func TestAPIV2UsesFinalEnforcer(t *testing.T) {
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/health", nil)
 	s.router.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Errorf("API-v2 status: got %d, want %d", rec.Code, http.StatusUnauthorized)
-	}
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 }
 
 // The update prompt in the UI compares this response against its own compiled-in version
@@ -77,34 +74,20 @@ func TestBuildInfo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := newTestServer(WithVersion(tt.version, tt.sha))
-			if err != nil {
-				t.Fatalf("building server: %v", err)
-			}
+			require.NoError(t, err)
 
 			rec := httptest.NewRecorder()
 			ctx := echo.New().
 				NewContext(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/version", nil), rec)
 
-			if err := s.buildInfo(ctx); err != nil {
-				t.Fatalf("buildInfo returned an error: %v", err)
-			}
-
-			if rec.Code != http.StatusOK {
-				t.Fatalf("expected 200, got %d", rec.Code)
-			}
+			require.NoError(t, s.buildInfo(ctx))
+			require.Equal(t, http.StatusOK, rec.Code)
 
 			var got map[string]string
-			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-				t.Fatalf("response is not valid JSON: %v (body %q)", err, rec.Body.String())
-			}
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 
-			if got["version"] != tt.wantVersion {
-				t.Errorf("version: got %q, want %q", got["version"], tt.wantVersion)
-			}
-
-			if got["sha"] != tt.wantSha {
-				t.Errorf("sha: got %q, want %q", got["sha"], tt.wantSha)
-			}
+			assert.Equal(t, tt.wantVersion, got["version"])
+			assert.Equal(t, tt.wantSha, got["sha"])
 		})
 	}
 }
@@ -113,30 +96,55 @@ func TestBuildInfo(t *testing.T) {
 // empty strings. Asserting it keeps that distinguishable from a real version.
 func TestBuildInfoWithoutVersionOption(t *testing.T) {
 	s, err := newTestServer()
-	if err != nil {
-		t.Fatalf("building server: %v", err)
-	}
+	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
 
 	ctx := echo.New().
 		NewContext(httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/version", nil), rec)
-	if err := s.buildInfo(ctx); err != nil {
-		t.Fatalf("buildInfo returned an error: %v", err)
-	}
+	require.NoError(t, s.buildInfo(ctx))
 
 	var got map[string]string
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("response is not valid JSON: %v", err)
-	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 
-	if _, ok := got["version"]; !ok {
-		t.Error("expected a version key even when unset, so clients can rely on the shape")
-	}
+	assert.Contains(t, got, "version", "expected a version key even when unset, so clients can rely on the shape")
+	assert.Contains(t, got, "sha", "expected a sha key even when unset, so clients can rely on the shape")
+}
 
-	if _, ok := got["sha"]; !ok {
-		t.Error("expected a sha key even when unset, so clients can rely on the shape")
+// Pre-26.9.0 clients call this removed endpoint from a stale cached bundle. Asserting the
+// exact response guards against a regression back to the SPA fallback serving index.html,
+// which is what a JSON-parsing old client chokes on.
+func TestLegacyGraphQLGone(t *testing.T) {
+	s := NewServer()
+
+	for _, path := range []string{"/v1/graphql", "/v1/graphql/ws"} {
+		t.Run(path, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, path, nil)
+			s.router.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusGone, rec.Code)
+			assert.Equal(t, `"cache", "storage"`, rec.Header().Get("Clear-Site-Data"))
+			assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+
+			var got map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+			assert.Contains(t, got, "errors")
+		})
 	}
+}
+
+// The static SPA fallback must still catch genuinely unknown paths; only the removed
+// legacy endpoint gets the Clear-Site-Data treatment.
+func TestUnrelatedUnmatchedPathStillFallsBackToSPA(t *testing.T) {
+	s := NewServer()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/some/unknown/route", nil)
+	s.router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Clear-Site-Data"))
 }
 
 func newTestServer(opts ...Option) (*Server, error) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -25,6 +25,11 @@ func (s *Server) RegisterRoutes() {
 	// served asset filenames do not already reveal.
 	s.router.GET("/version", s.buildInfo)
 
+	// Removed pre-26.9.0 endpoint; see legacyGraphQLGone for why this needs its own route
+	// rather than falling through to the SPA static fallback.
+	s.router.Any("/v1/graphql", s.legacyGraphQLGone)
+	s.router.Any("/v1/graphql/*", s.legacyGraphQLGone)
+
 	// OIDC handlers
 	oidc := s.router.Group("/oauth2")
 	oidc.GET("/sign_in", s.SignInHandler)


### PR DESCRIPTION
Details:
* old clients are hitting the OLD hasura graphql endpoint and getting index.html served instead, causing a JSON error.
* This PR proposes a new handler instructing the client to clear the side data, including the registered service worker: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Clear-Site-Data