### PR TITLE
fix(otel): use typed slog attributes so log fields survive OTLP export

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -143,6 +143,7 @@ linters:
       require-explanation: true
       require-specific: true
     sloglint:
+      attr-only: true
       context: scope
       key-naming-case: snake
       msg-style: lowercased

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,16 +223,59 @@ at startup by `internal/cli/log.go` and replaced with the OTel fan-out logger wh
 `OTEL_EXPORTER_OTLP_ENDPOINT` is set (`internal/cli/otel.go`). You never initialise a logger
 yourself — use the package-level functions.
 
+### Always use typed `slog.Attr` constructors
+
+Never pass loose alternating key/value pairs. The console handler stringifies values
+automatically; the OTel log bridge does not, so untyped values lose their type — or are dropped —
+once logs are exported. `sloglint`'s `attr-only` rule enforces this.
+
+```go
+// correct — typed attributes
+slog.DebugContext(ctx, "creating layer",
+    slog.String("incident_id", incidentID.String()),
+    slog.String("actor", actor.Sub))
+slog.InfoContext(ctx, "migration applied", slog.Int64("version", r.Source.Version))
+slog.ErrorContext(ctx, "service error",
+    slog.String("operation", op), slog.String("error", err.Error()))
+
+// wrong — loose key/value pairs
+slog.DebugContext(ctx, "creating layer", "incident_id", incidentID, "actor", actor.Sub)
+```
+
+Mapping rules:
+
+| Value                                             | Attribute                                  |
+| ------------------------------------------------- | ------------------------------------------ |
+| `uuid.UUID`, domain IDs, anything with `String()` | `slog.String(k, v.String())`               |
+| `error`                                           | `slog.String("error", err.Error())`        |
+| named string types (`shared.TriageStatus`, …)     | `slog.String(k, string(v))`                |
+| `int` / `int64` / `uint`                          | `slog.Int` / `slog.Int64` / `slog.Uint64`  |
+| `bool`, `float64`                                 | `slog.Bool`, `slog.Float64`                |
+| `time.Time`, `time.Duration`                      | `slog.Time`, `slog.Duration`               |
+| slices                                            | render to a string (e.g. `strings.Join`)   |
+
+Keys are `snake_case`; the error key is always `error`. `slog.Any` is a last resort — prefer
+rendering the value explicitly.
+
+When attributes are assembled conditionally into a `[]slog.Attr`, log via `slog.LogAttrs`
+(a `[]slog.Attr` cannot be spread into the `...any` parameter of `InfoContext` & co.):
+
+```go
+attrs := []slog.Attr{slog.String("operation", op)}
+if fieldCtx != nil {
+    attrs = append(attrs, slog.String("path", fieldCtx.Path().String()))
+}
+
+slog.LogAttrs(ctx, slog.LevelError, "resolver error", attrs...)
+```
+
 ### Always pass context
 
 Use the `Context` variants so that trace/span IDs are attached to every log line automatically:
 
 ```go
 // correct — span IDs flow through
-slog.DebugContext(ctx, "creating layer", "incident_id", incidentID, "actor", actor.Sub)
-slog.InfoContext(ctx, "migration applied", "version", r.Source.Version)
-slog.WarnContext(ctx, "preflight finding", "finding", w)
-slog.ErrorContext(ctx, "service error", "operation", op, "error", err)
+slog.DebugContext(ctx, "creating layer", slog.String("incident_id", incidentID.String()))
 
 // wrong — never use the context-free variants inside request paths
 slog.Debug("creating layer", ...)
@@ -258,7 +301,8 @@ func NewProjector(...) *Projector {
 }
 
 // usage inside the struct — still passes ctx for trace correlation
-p.log.Info("projection caught up", "handler", h.Name(), "applied", n)
+p.log.InfoContext(ctx, "projection caught up",
+    slog.String("handler", h.Name()), slog.Int("applied", n))
 ```
 
 ### Log levels
@@ -276,7 +320,11 @@ p.log.Info("projection caught up", "handler", h.Name(), "applied", n)
 expected domain sentinels (`ErrNotFound`, `ErrIncidentNotOpen`, `ErrAlreadyClosed`, …). Those
 errors are normal business outcomes and are handled at the resolver boundary. Only call
 `logIfUnexpected` (or log at `Error`) for infrastructure failures that indicate something is
-genuinely broken.
+genuinely broken. It takes `...slog.Attr` — pass typed attributes:
+
+```go
+logIfUnexpected(ctx, "UpdateIncident", err, slog.String("id", id.String()))
+```
 
 ---
 

--- a/internal/adapter/outbound/eventstore/inmem/projection/projector.go
+++ b/internal/adapter/outbound/eventstore/inmem/projection/projector.go
@@ -184,7 +184,7 @@ func (p *Projector) Reset(ctx context.Context) (err error) {
 // CatchUp.
 func (p *Projector) Run(ctx context.Context) error {
 	if err := p.CatchUp(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		p.log.ErrorContext(ctx, "inmem projector initial catch-up failed", "error", err)
+		p.log.ErrorContext(ctx, "inmem projector initial catch-up failed", slog.String("error", err.Error()))
 		return err
 	}
 
@@ -209,7 +209,7 @@ func (p *Projector) Run(ctx context.Context) error {
 		}
 
 		if err := p.CatchUp(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			p.log.ErrorContext(ctx, "inmem projector catch-up failed", "error", err)
+			p.log.ErrorContext(ctx, "inmem projector catch-up failed", slog.String("error", err.Error()))
 		}
 	}
 }

--- a/internal/adapter/outbound/eventstore/postgres/lock.go
+++ b/internal/adapter/outbound/eventstore/postgres/lock.go
@@ -109,7 +109,7 @@ func (l *ProjectorLock) Acquire(ctx context.Context, projection string) (func(),
 				`SELECT pg_advisory_unlock($1, $2)`, lockClassID, key)
 			if unlockErr != nil {
 				l.log.WarnContext(unlockCtx, "projector lock: advisory unlock failed — lock released by session end",
-					"error", unlockErr)
+					slog.String("error", unlockErr.Error()))
 			}
 
 			l.mu.Lock()

--- a/internal/adapter/outbound/eventstore/postgres/projection/projector.go
+++ b/internal/adapter/outbound/eventstore/postgres/projection/projector.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -213,7 +214,7 @@ func (p *Projector) Run(ctx context.Context) error {
 		names[i] = h.Name()
 	}
 
-	p.log.InfoContext(ctx, "projector starting", "handlers", names)
+	p.log.InfoContext(ctx, "projector starting", slog.String("handlers", strings.Join(names, ",")))
 
 	for {
 		release, err := p.acquireLock(ctx)
@@ -222,13 +223,13 @@ func (p *Projector) Run(ctx context.Context) error {
 			p.lockContended.Add(ctx, 1)
 			p.log.DebugContext(ctx, "another instance is leading, standing by")
 		case err != nil:
-			p.log.ErrorContext(ctx, "projector lock acquisition failed", "error", err)
+			p.log.ErrorContext(ctx, "projector lock acquisition failed", slog.String("error", err.Error()))
 		default:
 			p.leaderAcquired.Add(ctx, 1)
-			p.log.InfoContext(ctx, "projector elected leader", "lock", p.lockName)
+			p.log.InfoContext(ctx, "projector elected leader", slog.String("lock", p.lockName))
 
 			if leadErr := p.lead(ctx, release); leadErr != nil && !errors.Is(leadErr, context.Canceled) {
-				p.log.WarnContext(ctx, "projector stepping down", "error", leadErr)
+				p.log.WarnContext(ctx, "projector stepping down", slog.String("error", leadErr.Error()))
 			}
 		}
 
@@ -267,7 +268,7 @@ func (p *Projector) lead(ctx context.Context, release func()) error {
 			// This build is older than the stored projection; yield to the
 			// newer replica instead of rebuilding read models backwards.
 			p.log.ErrorContext(ctx, "this build is older than the stored projection, yielding leadership",
-				"error", err)
+				slog.String("error", err.Error()))
 		}
 
 		return fmt.Errorf("projector: init checkpoints: %w", err)
@@ -293,7 +294,8 @@ func (p *Projector) lead(ctx context.Context, release func()) error {
 
 			consecutiveFailures++
 			p.log.ErrorContext(ctx, "projector catch-up failed",
-				"error", err, "consecutive_failures", consecutiveFailures)
+				slog.String("error", err.Error()),
+				slog.Int("consecutive_failures", consecutiveFailures))
 
 			if consecutiveFailures >= maxConsecutiveCatchUpFailures {
 				return fmt.Errorf("%w after %d failures: %w", errCatchUpStuck, consecutiveFailures, err)
@@ -477,7 +479,9 @@ func (p *Projector) catchUp(ctx context.Context) (err error) {
 							attribute.String("event.type", e.EventType),
 							attribute.Int("event.version", e.Version),
 						))
-					p.log.ErrorContext(ctx, "handler failed after retries", "handler", h.Name(), "error", err)
+					p.log.ErrorContext(ctx, "handler failed after retries",
+						slog.String("handler", h.Name()),
+						slog.String("error", err.Error()))
 					p.handlerErrors.Add(ctx, 1, metric.WithAttributes(handlerAttr, attribute.String("type", "apply")))
 					// park the event and continue — the projection is now known-incomplete
 					if parkErr := p.parkDeadLetter(ctx, h.Name(), next, e, err); parkErr != nil {
@@ -490,7 +494,7 @@ func (p *Projector) catchUp(ctx context.Context) (err error) {
 								attribute.String("event.type", e.EventType),
 								attribute.Int("event.version", e.Version),
 							))
-						p.log.ErrorContext(ctx, "failed to park dead letter", "error", parkErr)
+						p.log.ErrorContext(ctx, "failed to park dead letter", slog.String("error", parkErr.Error()))
 					} else {
 						p.deadLetters.Add(ctx, 1, metric.WithAttributes(handlerAttr))
 					}
@@ -514,14 +518,16 @@ func (p *Projector) catchUp(ctx context.Context) (err error) {
 		}
 
 		if handlerApplied > 0 {
-			p.log.InfoContext(ctx, "projection caught up", "handler", h.Name(), "applied", handlerApplied)
+			p.log.InfoContext(ctx, "projection caught up",
+				slog.String("handler", h.Name()),
+				slog.Int("applied", handlerApplied))
 		}
 
 		totalApplied += handlerApplied
 	}
 
 	if totalApplied > 0 {
-		p.log.InfoContext(ctx, "catch-up complete", "total_applied", totalApplied)
+		p.log.InfoContext(ctx, "catch-up complete", slog.Int("total_applied", totalApplied))
 	}
 
 	p.catchupDur.Record(ctx, time.Since(start).Seconds())
@@ -632,13 +638,17 @@ func (p *Projector) initCheckpoints(ctx context.Context) (err error) {
 			// Stored version is ahead of this build — a newer replica has already
 			// upgraded the projection. Refuse to rebuild it back to an older schema.
 			p.log.ErrorContext(ctx, "projection is newer than this build, refusing to rebuild",
-				"handler", h.Name(), "stored", storedVersion, "build", h.Version())
+				slog.String("handler", h.Name()),
+				slog.Int("stored", storedVersion),
+				slog.Int("build", h.Version()))
 
 			return fmt.Errorf("%w: %s at v%d, build has v%d",
 				errProjectionAhead, h.Name(), storedVersion, h.Version())
 		case storedVersion < h.Version():
 			p.log.InfoContext(ctx, "projection version changed, rebuilding",
-				"handler", h.Name(), "was", storedVersion, "now", h.Version())
+				slog.String("handler", h.Name()),
+				slog.Int("was", storedVersion),
+				slog.Int("now", h.Version()))
 
 			if err := p.resetProjection(ctx, h); err != nil {
 				return err

--- a/internal/adapter/outbound/eventstore/postgres/retention.go
+++ b/internal/adapter/outbound/eventstore/postgres/retention.go
@@ -123,7 +123,9 @@ func (r *IncidentRetention) Archive(ctx context.Context, incidentID shared.Incid
 	}
 
 	slog.InfoContext(ctx, "archived incident event-store data",
-		"incident_id", incidentID, "events", archiveEvents, "streams", archiveStreams)
+		slog.String("incident_id", incidentID.String()),
+		slog.Int64("events", archiveEvents),
+		slog.Int64("streams", archiveStreams))
 
 	return nil
 }

--- a/internal/adapter/outbound/queries/inmem/queries.go
+++ b/internal/adapter/outbound/queries/inmem/queries.go
@@ -64,13 +64,13 @@ func (q *Queries) ListIncidents(ctx context.Context) ([]*outbound.IncidentRM, er
 	sort.Slice(out, func(i, j int) bool {
 		return out[i].CreatedAt.After(out[j].CreatedAt)
 	})
-	slog.DebugContext(ctx, "listed incidents", "count", len(out))
+	slog.DebugContext(ctx, "listed incidents", slog.Int("count", len(out)))
 
 	return out, nil
 }
 
 func (q *Queries) GetIncident(ctx context.Context, id uuid.UUID) (*outbound.IncidentRM, error) {
-	slog.DebugContext(ctx, "getting incident", "id", id)
+	slog.DebugContext(ctx, "getting incident", slog.String("id", id.String()))
 
 	row := q.incidents.Get(id)
 	if row == nil || row.IsDeleted {
@@ -107,7 +107,7 @@ func (q *Queries) toIncidentRM(row *projection.IncidentRow) *outbound.IncidentRM
 // ──────────────────────────────────────────────────────────────────────────────
 
 func (q *Queries) ListMessages(ctx context.Context, incidentID uuid.UUID) ([]*outbound.MessageRM, error) {
-	slog.DebugContext(ctx, "listing messages", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing messages", slog.String("incident_id", incidentID.String()))
 	rows := q.messages.ForIncident(incidentID)
 
 	out := make([]*outbound.MessageRM, 0, len(rows))
@@ -127,7 +127,7 @@ func (q *Queries) ListMessages(ctx context.Context, incidentID uuid.UUID) ([]*ou
 }
 
 func (q *Queries) GetMessage(ctx context.Context, id uuid.UUID) (*outbound.MessageRM, error) {
-	slog.DebugContext(ctx, "getting message", "id", id)
+	slog.DebugContext(ctx, "getting message", slog.String("id", id.String()))
 
 	row := q.messages.Get(id)
 	if row == nil || row.Deleted {
@@ -162,14 +162,14 @@ func toMessageRM(row *projection.MessageRow) *outbound.MessageRM {
 // ──────────────────────────────────────────────────────────────────────────────
 
 func (q *Queries) ListLayers(ctx context.Context, incidentID uuid.UUID) ([]*outbound.LayerRM, error) {
-	slog.DebugContext(ctx, "listing layers", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing layers", slog.String("incident_id", incidentID.String()))
 	rows := q.layers.ForIncident(incidentID)
 
 	return q.layerRowsToRM(rows, nil), nil
 }
 
 func (q *Queries) ListVisibleLayers(ctx context.Context, incidentID uuid.UUID) ([]*outbound.LayerRM, error) {
-	slog.DebugContext(ctx, "listing visible layers", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing visible layers", slog.String("incident_id", incidentID.String()))
 
 	rows := q.layers.ForIncident(incidentID)
 	for _, incidentRow := range q.incidents.All() {
@@ -184,7 +184,7 @@ func (q *Queries) ListVisibleLayers(ctx context.Context, incidentID uuid.UUID) (
 }
 
 func (q *Queries) ListChildIncidents(ctx context.Context, parentID uuid.UUID) ([]*outbound.IncidentRM, error) {
-	slog.DebugContext(ctx, "listing child incidents", "parent_id", parentID)
+	slog.DebugContext(ctx, "listing child incidents", slog.String("parent_id", parentID.String()))
 
 	var out []*outbound.IncidentRM
 

--- a/internal/adapter/outbound/queries/postgres/queries.go
+++ b/internal/adapter/outbound/queries/postgres/queries.go
@@ -67,13 +67,13 @@ func (q *Queries) ListIncidents(ctx context.Context) ([]*outbound.IncidentRM, er
 		return nil, err
 	}
 
-	slog.DebugContext(ctx, "listed incidents", "count", len(out))
+	slog.DebugContext(ctx, "listed incidents", slog.Int("count", len(out)))
 
 	return out, nil
 }
 
 func (q *Queries) GetIncident(ctx context.Context, id uuid.UUID) (*outbound.IncidentRM, error) {
-	slog.DebugContext(ctx, "getting incident", "id", id)
+	slog.DebugContext(ctx, "getting incident", slog.String("id", id.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT id, parent_id, name, is_closed, closed_at, created_at, updated_at, location
@@ -150,7 +150,7 @@ func scanIncident(row incidentScanner) (*outbound.IncidentRM, error) {
 }
 
 func (q *Queries) ListChildIncidents(ctx context.Context, parentID uuid.UUID) ([]*outbound.IncidentRM, error) {
-	slog.DebugContext(ctx, "listing child incidents", "parent_id", parentID)
+	slog.DebugContext(ctx, "listing child incidents", slog.String("parent_id", parentID.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT id, parent_id, name, is_closed, closed_at, created_at, updated_at, location
@@ -238,7 +238,7 @@ func (q *Queries) loadDivisions(ctx context.Context, incidents []*outbound.Incid
 // ──────────────────────────────────────────────────────────────────────────────
 
 func (q *Queries) ListMessages(ctx context.Context, incidentID uuid.UUID) ([]*outbound.MessageRM, error) {
-	slog.DebugContext(ctx, "listing messages", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing messages", slog.String("incident_id", incidentID.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT id, number, incident_id, content, sender, sender_detail,
@@ -256,7 +256,7 @@ func (q *Queries) ListMessages(ctx context.Context, incidentID uuid.UUID) ([]*ou
 }
 
 func (q *Queries) GetMessage(ctx context.Context, id uuid.UUID) (*outbound.MessageRM, error) {
-	slog.DebugContext(ctx, "getting message", "id", id)
+	slog.DebugContext(ctx, "getting message", slog.String("id", id.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT id, number, incident_id, content, sender, sender_detail,
@@ -339,7 +339,7 @@ func collectMessages(rows pgx.Rows) ([]*outbound.MessageRM, error) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 func (q *Queries) ListLayers(ctx context.Context, incidentID uuid.UUID) ([]*outbound.LayerRM, error) {
-	slog.DebugContext(ctx, "listing layers", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing layers", slog.String("incident_id", incidentID.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT l.id, l.incident_id, i.name AS source_incident_name, l.name, l.geojson, l.revision
@@ -356,7 +356,7 @@ func (q *Queries) ListLayers(ctx context.Context, incidentID uuid.UUID) ([]*outb
 }
 
 func (q *Queries) ListVisibleLayers(ctx context.Context, incidentID uuid.UUID) ([]*outbound.LayerRM, error) {
-	slog.DebugContext(ctx, "listing visible layers", "incident_id", incidentID)
+	slog.DebugContext(ctx, "listing visible layers", slog.String("incident_id", incidentID.String()))
 
 	rows, err := q.pool.Query(ctx, `
 		SELECT l.id, l.incident_id, i.name AS source_incident_name, l.name, l.geojson, l.revision

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -82,7 +82,7 @@ func openGooseDBWithRetry(
 		}
 
 		lastErr = err
-		slog.InfoContext(ctx, "waiting for database connection", "error", err)
+		slog.InfoContext(ctx, "waiting for database connection", slog.String("error", err.Error()))
 
 		retry := time.NewTimer(interval)
 		select {
@@ -134,12 +134,9 @@ func runMigrateUp(cmd *cobra.Command, dsn string) error {
 		slog.InfoContext(
 			cmd.Context(),
 			"migration applied",
-			"version",
-			r.Source.Version,
-			"type",
-			r.Source.Type,
-			"duration",
-			r.Duration,
+			slog.Int64("version", r.Source.Version),
+			slog.String("type", string(r.Source.Type)),
+			slog.Duration("duration", r.Duration),
 		)
 	}
 
@@ -173,7 +170,7 @@ func runMigrateDown(cmd *cobra.Command, dsn string) error {
 		return err
 	}
 
-	slog.InfoContext(cmd.Context(), "migration rolled back", "version", result.Source.Version)
+	slog.InfoContext(cmd.Context(), "migration rolled back", slog.Int64("version", result.Source.Version))
 
 	return nil
 }
@@ -236,7 +233,7 @@ func runMigratePreflight(cmd *cobra.Command, dsn string) error {
 
 	warnings, err := migrations.RunPreflight(cmd.Context(), db)
 	for _, w := range warnings {
-		slog.WarnContext(cmd.Context(), "preflight", "finding", w)
+		slog.WarnContext(cmd.Context(), "preflight", slog.String("finding", w))
 	}
 
 	if err != nil {
@@ -246,7 +243,7 @@ func runMigratePreflight(cmd *cobra.Command, dsn string) error {
 	if len(warnings) == 0 {
 		slog.InfoContext(cmd.Context(), "preflight: all checks passed — data is ready to import")
 	} else {
-		slog.InfoContext(cmd.Context(), "preflight: checks passed with warnings", "count", len(warnings))
+		slog.InfoContext(cmd.Context(), "preflight: checks passed with warnings", slog.Int("count", len(warnings)))
 	}
 
 	return nil

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -66,16 +66,16 @@ func newServeCmd(v *viper.Viper) (*cobra.Command, error) {
 
 func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 	ctx := cmd.Context()
-	slog.InfoContext(ctx, "starting sitrep", "version", Version, "sha", Sha)
+	slog.InfoContext(ctx, "starting sitrep", slog.String("version", Version), slog.String("sha", Sha))
 
 	shutdown, err := setupOpenTelemetry(ctx)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed to configure OpenTelemetry", "error", err)
+		slog.ErrorContext(ctx, "failed to configure OpenTelemetry", slog.String("error", err.Error()))
 		return err
 	}
 	defer func() {
 		if err := shutdown(ctx); err != nil {
-			slog.ErrorContext(ctx, "failed to shutdown OpenTelemetry", "error", err)
+			slog.ErrorContext(ctx, "failed to shutdown OpenTelemetry", slog.String("error", err.Error()))
 		}
 	}()
 
@@ -83,7 +83,7 @@ func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 		slog.InfoContext(ctx, "running startup migrations")
 
 		if err := runMigrateUp(cmd, v.GetString("database-url")); err != nil {
-			slog.ErrorContext(ctx, "failed to run startup migrations", "error", err)
+			slog.ErrorContext(ctx, "failed to run startup migrations", slog.String("error", err.Error()))
 			return err
 		}
 	}
@@ -119,7 +119,7 @@ func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 			deriveCookieKey(v.GetString("cookie-key")),
 		)
 		if err != nil {
-			slog.ErrorContext(ctx, "failed to create OIDC client", "error", err)
+			slog.ErrorContext(ctx, "failed to create OIDC client", slog.String("error", err.Error()))
 			return err
 		}
 
@@ -134,7 +134,7 @@ func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 
 	srv := server.NewServer(opts...)
 	if err := srv.ListenAndServe(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		slog.ErrorContext(ctx, "failed to start server", "error", err)
+		slog.ErrorContext(ctx, "failed to start server", slog.String("error", err.Error()))
 		return err
 	}
 

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -110,7 +110,7 @@ func buildPostgresStack(ctx context.Context, dsn string, autoCloseDays, autoArch
 		defer close(projDone)
 
 		if err := proj.Run(projCtx); err != nil && !errors.Is(err, context.Canceled) {
-			slog.ErrorContext(projCtx, "projector stopped unexpectedly", "error", err)
+			slog.ErrorContext(projCtx, "projector stopped unexpectedly", slog.String("error", err.Error()))
 		}
 	}()
 
@@ -170,7 +170,7 @@ func buildInmemStack(ctx context.Context) (*stack, error) {
 		defer close(projDone)
 
 		if err := proj.Run(projCtx); err != nil && !errors.Is(err, context.Canceled) {
-			slog.ErrorContext(projCtx, "projector stopped unexpectedly", "error", err)
+			slog.ErrorContext(projCtx, "projector stopped unexpectedly", slog.String("error", err.Error()))
 		}
 	}()
 

--- a/internal/core/service/assertions.go
+++ b/internal/core/service/assertions.go
@@ -20,7 +20,7 @@ var (
 // logIfUnexpected logs err at error level when it is an infrastructure/unexpected
 // error. Domain errors are intentionally excluded — they are expected business
 // outcomes and are logged at the resolver boundary.
-func logIfUnexpected(ctx context.Context, op string, err error, attrs ...any) {
+func logIfUnexpected(ctx context.Context, op string, err error, attrs ...slog.Attr) {
 	if err == nil {
 		return
 	}
@@ -38,5 +38,6 @@ func logIfUnexpected(ctx context.Context, op string, err error, attrs ...any) {
 		return
 	}
 
-	slog.ErrorContext(ctx, "service error", append([]any{"operation", op, "error", err}, attrs...)...)
+	slog.LogAttrs(ctx, slog.LevelError, "service error",
+		append([]slog.Attr{slog.String("operation", op), slog.String("error", err.Error())}, attrs...)...)
 }

--- a/internal/core/service/feature.go
+++ b/internal/core/service/feature.go
@@ -59,7 +59,10 @@ func (s *FeatureService) PlaceFeature(
 		))
 	defer span.End()
 
-	slog.DebugContext(ctx, "placing feature", "feature_id", id, "layer_id", layerID, "actor", actor.Sub)
+	slog.DebugContext(ctx, "placing feature",
+		slog.String("feature_id", id.String()),
+		slog.String("layer_id", layerID.String()),
+		slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -112,7 +115,8 @@ func (s *FeatureService) ModifyFeature(
 		trace.WithAttributes(attribute.String("feature.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "modifying feature", "feature_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "modifying feature",
+		slog.String("feature_id", id.String()), slog.String("actor", actor.Sub))
 
 	var state inbound.FeatureState
 
@@ -154,7 +158,8 @@ func (s *FeatureService) RemoveFeature(ctx context.Context, id shared.FeatureID,
 		trace.WithAttributes(attribute.String("feature.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "removing feature", "feature_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "removing feature",
+		slog.String("feature_id", id.String()), slog.String("actor", actor.Sub))
 
 	err := s.writeFeature(ctx, id, func(f *feature.Feature) error {
 		return f.Remove(shared.DeleteReasonManual, actor.Sub, s.clock.Now())

--- a/internal/core/service/incident.go
+++ b/internal/core/service/incident.go
@@ -76,7 +76,13 @@ func (s *IncidentService) CreateIncidentWithParent(
 		trace.WithAttributes(attribute.String("incident.name", name)))
 	defer span.End()
 
-	slog.DebugContext(ctx, "creating incident", "name", name, "parent_id", parentID, "actor", actor.Sub)
+	parentAttr := slog.String("parent_id", "")
+	if parentID != nil {
+		parentAttr = slog.String("parent_id", parentID.String())
+	}
+
+	slog.DebugContext(ctx, "creating incident",
+		slog.String("name", name), parentAttr, slog.String("actor", actor.Sub))
 
 	if len(layerNames) == 0 {
 		layerNames = []string{"Lage"}
@@ -143,13 +149,14 @@ func (s *IncidentService) CreateIncidentWithParent(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "CreateIncident", err, "name", name)
+		logIfUnexpected(ctx, "CreateIncident", err, slog.String("name", name))
 
 		return inbound.CreateIncidentResult{}, err
 	}
 
 	span.SetAttributes(attribute.String("incident.id", incID.String()))
-	slog.DebugContext(ctx, "incident created", "incident_id", incID, "layers", len(layerIDs))
+	slog.DebugContext(ctx, "incident created",
+		slog.String("incident_id", incID.String()), slog.Int("layers", len(layerIDs)))
 	_ = s.notifier.Notify(ctx)
 
 	return inbound.CreateIncidentResult{
@@ -176,7 +183,8 @@ func (s *IncidentService) UpdateIncident(
 		trace.WithAttributes(attribute.String("incident.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "updating incident", "incident_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "updating incident",
+		slog.String("incident_id", id.String()), slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -224,7 +232,7 @@ func (s *IncidentService) UpdateIncident(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "UpdateIncident", err, "id", id)
+		logIfUnexpected(ctx, "UpdateIncident", err, slog.String("id", id.String()))
 
 		return inbound.IncidentState{}, err
 	}
@@ -244,7 +252,8 @@ func (s *IncidentService) CloseIncident(
 		trace.WithAttributes(attribute.String("incident.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "closing incident", "incident_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "closing incident",
+		slog.String("incident_id", id.String()), slog.String("actor", actor.Sub))
 
 	state, err := s.writeIncident(ctx, id, func(inc *incident.Incident) error {
 		return inc.Close(shared.ReasonManual, actor.Sub, s.clock.Now())
@@ -267,7 +276,8 @@ func (s *IncidentService) ReopenIncident(
 		trace.WithAttributes(attribute.String("incident.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "reopening incident", "incident_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "reopening incident",
+		slog.String("incident_id", id.String()), slog.String("actor", actor.Sub))
 
 	state, err := s.writeIncident(ctx, id, func(inc *incident.Incident) error {
 		return inc.Reopen(actor.Sub, s.clock.Now())
@@ -286,7 +296,8 @@ func (s *IncidentService) DeleteIncident(ctx context.Context, id shared.Incident
 		trace.WithAttributes(attribute.String("incident.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "deleting incident", "incident_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "deleting incident",
+		slog.String("incident_id", id.String()), slog.String("actor", actor.Sub))
 
 	_, err := s.writeIncident(ctx, id, func(inc *incident.Incident) error {
 		return inc.Delete(shared.DeleteReasonManual, actor.Sub, s.clock.Now())
@@ -311,7 +322,10 @@ func (s *IncidentService) LinkIncidentParent(
 		))
 	defer span.End()
 
-	slog.DebugContext(ctx, "linking incident parent", "child_id", childID, "parent_id", parentID, "actor", actor.Sub)
+	slog.DebugContext(ctx, "linking incident parent",
+		slog.String("child_id", childID.String()),
+		slog.String("parent_id", parentID.String()),
+		slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -348,7 +362,8 @@ func (s *IncidentService) LinkIncidentParent(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "LinkIncidentParent", err, "child_id", childID, "parent_id", parentID)
+		logIfUnexpected(ctx, "LinkIncidentParent", err,
+			slog.String("child_id", childID.String()), slog.String("parent_id", parentID.String()))
 
 		return inbound.IncidentState{}, err
 	}
@@ -367,7 +382,8 @@ func (s *IncidentService) UnlinkIncidentParent(
 		trace.WithAttributes(attribute.String("incident.child_id", childID.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "unlinking incident parent", "child_id", childID, "actor", actor.Sub)
+	slog.DebugContext(ctx, "unlinking incident parent",
+		slog.String("child_id", childID.String()), slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -400,7 +416,7 @@ func (s *IncidentService) UnlinkIncidentParent(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "UnlinkIncidentParent", err, "child_id", childID)
+		logIfUnexpected(ctx, "UnlinkIncidentParent", err, slog.String("child_id", childID.String()))
 
 		return inbound.IncidentState{}, err
 	}
@@ -466,7 +482,7 @@ func (s *IncidentService) writeIncident(
 		return nil
 	})
 	if err != nil {
-		logIfUnexpected(ctx, "writeIncident", err, "id", id)
+		logIfUnexpected(ctx, "writeIncident", err, slog.String("id", id.String()))
 		return inbound.IncidentState{}, err
 	}
 

--- a/internal/core/service/layer.go
+++ b/internal/core/service/layer.go
@@ -54,7 +54,10 @@ func (s *LayerService) CreateLayer(
 		))
 	defer span.End()
 
-	slog.DebugContext(ctx, "creating layer", "incident_id", incidentID, "name", name, "actor", actor.Sub)
+	slog.DebugContext(ctx, "creating layer",
+		slog.String("incident_id", incidentID.String()),
+		slog.String("name", name),
+		slog.String("actor", actor.Sub))
 
 	layerID := shared.LayerID(s.ids.New())
 	at := s.clock.Now()
@@ -93,7 +96,10 @@ func (s *LayerService) RenameLayer(ctx context.Context, id shared.LayerID, name 
 		trace.WithAttributes(attribute.String("layer.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "renaming layer", "layer_id", id, "name", name, "actor", actor.Sub)
+	slog.DebugContext(ctx, "renaming layer",
+		slog.String("layer_id", id.String()),
+		slog.String("name", name),
+		slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -133,7 +139,8 @@ func (s *LayerService) RemoveLayer(ctx context.Context, id shared.LayerID, actor
 		trace.WithAttributes(attribute.String("layer.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "removing layer", "layer_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "removing layer",
+		slog.String("layer_id", id.String()), slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 

--- a/internal/core/service/message.go
+++ b/internal/core/service/message.go
@@ -59,7 +59,8 @@ func (s *MessageService) RecordMessage(
 		trace.WithAttributes(attribute.String("incident.id", incidentID.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "recording message", "incident_id", incidentID, "actor", actor.Sub)
+	slog.DebugContext(ctx, "recording message",
+		slog.String("incident_id", incidentID.String()), slog.String("actor", actor.Sub))
 
 	msgID := shared.MessageID(s.ids.New())
 
@@ -98,7 +99,7 @@ func (s *MessageService) RecordMessage(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "RecordMessage", err, "incidentId", incidentID)
+		logIfUnexpected(ctx, "RecordMessage", err, slog.String("incident_id", incidentID.String()))
 
 		return inbound.MessageState{}, err
 	}
@@ -123,7 +124,8 @@ func (s *MessageService) CorrectMessage(
 		trace.WithAttributes(attribute.String("message.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "correcting message", "message_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "correcting message",
+		slog.String("message_id", id.String()), slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -155,7 +157,7 @@ func (s *MessageService) CorrectMessage(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "CorrectMessage", err, "id", id)
+		logIfUnexpected(ctx, "CorrectMessage", err, slog.String("id", id.String()))
 
 		return inbound.MessageState{}, err
 	}
@@ -178,7 +180,10 @@ func (s *MessageService) TriageMessage(
 		trace.WithAttributes(attribute.String("message.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "triaging message", "message_id", id, "triage", triage, "actor", actor.Sub)
+	slog.DebugContext(ctx, "triaging message",
+		slog.String("message_id", id.String()),
+		slog.String("triage", string(triage)),
+		slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -225,7 +230,7 @@ func (s *MessageService) TriageMessage(
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "TriageMessage", err, "id", id)
+		logIfUnexpected(ctx, "TriageMessage", err, slog.String("id", id.String()))
 
 		return inbound.MessageState{}, err
 	}
@@ -241,7 +246,8 @@ func (s *MessageService) DeleteMessage(ctx context.Context, id shared.MessageID,
 		trace.WithAttributes(attribute.String("message.id", id.String())))
 	defer span.End()
 
-	slog.DebugContext(ctx, "deleting message", "message_id", id, "actor", actor.Sub)
+	slog.DebugContext(ctx, "deleting message",
+		slog.String("message_id", id.String()), slog.String("actor", actor.Sub))
 
 	at := s.clock.Now()
 
@@ -266,7 +272,7 @@ func (s *MessageService) DeleteMessage(ctx context.Context, id shared.MessageID,
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		logIfUnexpected(ctx, "DeleteMessage", err, "id", id)
+		logIfUnexpected(ctx, "DeleteMessage", err, slog.String("id", id.String()))
 
 		return err
 	}

--- a/internal/core/service/retention.go
+++ b/internal/core/service/retention.go
@@ -51,7 +51,7 @@ func NewRetentionService(
 	}
 }
 
-// Run applies enabled retention policies. A zero day count disables its policy.
+// Run applies enabled retention policies. A zero dacutoffy count disables its policy.
 func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDays uint) (RetentionResult, error) {
 	ctx, span := s.tracer.Start(ctx, "RetentionService.Run",
 		trace.WithAttributes(
@@ -64,14 +64,15 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 	now := s.clock.Now()
 
 	slog.DebugContext(ctx, "running incident retention",
-		"auto_close_days", autoCloseDays, "auto_archive_days", autoArchiveDays)
+		slog.Uint64("auto_close_days", uint64(autoCloseDays)),
+		slog.Uint64("auto_archive_days", uint64(autoArchiveDays)))
 
 	if autoCloseDays > 0 {
 		cutoff := now.AddDate(0, 0, -int(autoCloseDays))
 
 		ids, err := s.retention.OpenBefore(ctx, cutoff, s.batchSize)
 		if err != nil {
-			logIfUnexpected(ctx, "Retention.OpenBefore", err, "cutoff", cutoff)
+			logIfUnexpected(ctx, "Retention.OpenBefore", err, slog.String("cutoff", cutoff.Format(time.RFC3339)))
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 
@@ -79,12 +80,14 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 		}
 
 		slog.InfoContext(ctx, "incident retention auto-close candidates",
-			"count", len(ids), "cutoff", cutoff, "batch_size", s.batchSize)
+			slog.Int("count", len(ids)),
+			slog.String("cutoff", cutoff.Format(time.RFC3339)),
+			slog.Int("batch_size", s.batchSize))
 
 		for _, id := range ids {
 			closed, err := s.close(ctx, id, now)
 			if err != nil {
-				logIfUnexpected(ctx, "Retention.Close", err, "incident_id", id)
+				logIfUnexpected(ctx, "Retention.Close", err, slog.String("incident_id", id.String()))
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
 
@@ -94,7 +97,7 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 			if closed {
 				result.Closed++
 
-				slog.InfoContext(ctx, "incident automatically closed", "incident_id", id)
+				slog.InfoContext(ctx, "incident automatically closed", slog.String("incident_id", id.String()))
 			}
 		}
 	} else {
@@ -107,8 +110,13 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 
 		ids, err := s.retention.ArchiveBefore(ctx, closedCutoff, deletedCutoff, s.batchSize)
 		if err != nil {
-			logIfUnexpected(ctx, "Retention.ArchiveBefore", err,
-				"closed_cutoff", closedCutoff, "deleted_cutoff", deletedCutoff)
+			logIfUnexpected(
+				ctx,
+				"Retention.ArchiveBefore",
+				err,
+				slog.String("closed_cutoff", closedCutoff.Format(time.RFC3339)),
+				slog.String("deleted_cutoff", deletedCutoff.Format(time.RFC3339)),
+			)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 
@@ -116,13 +124,15 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 		}
 
 		slog.InfoContext(ctx, "incident retention archive candidates",
-			"count", len(ids), "closed_cutoff", closedCutoff,
-			"deleted_cutoff", deletedCutoff, "batch_size", s.batchSize)
+			slog.Int("count", len(ids)),
+			slog.String("closed_cutoff", closedCutoff.Format(time.RFC3339)),
+			slog.String("deleted_cutoff", deletedCutoff.Format(time.RFC3339)),
+			slog.Int("batch_size", s.batchSize))
 
 		for _, id := range ids {
 			archived, err := s.archive(ctx, id, now)
 			if err != nil {
-				logIfUnexpected(ctx, "Retention.Archive", err, "incident_id", id)
+				logIfUnexpected(ctx, "Retention.Archive", err, slog.String("incident_id", id.String()))
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
 
@@ -132,7 +142,7 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 			if archived {
 				result.Archived++
 
-				slog.InfoContext(ctx, "incident event streams archived", "incident_id", id)
+				slog.InfoContext(ctx, "incident event streams archived", slog.String("incident_id", id.String()))
 			}
 		}
 	} else {
@@ -152,7 +162,8 @@ func (s *RetentionService) Run(ctx context.Context, autoCloseDays, autoArchiveDa
 		attribute.Int("retention.closed", result.Closed),
 		attribute.Int("retention.archived", result.Archived),
 	)
-	slog.InfoContext(ctx, "incident retention complete", "closed", result.Closed, "archived", result.Archived)
+	slog.InfoContext(ctx, "incident retention complete",
+		slog.Int("closed", result.Closed), slog.Int("archived", result.Archived))
 
 	return result, nil
 }

--- a/server/auth/oidc.go
+++ b/server/auth/oidc.go
@@ -155,7 +155,12 @@ func (o *OIDCClient) marshalUserinfo(
 			)
 
 			if err := o.users.Upsert(r.Context(), info.Subject, info.Email, info.Name); err != nil {
-				o.logger.ErrorContext(r.Context(), "failed to upsert user on login", "sub", info.Subject, "error", err)
+				o.logger.ErrorContext(
+					r.Context(),
+					"failed to upsert user on login",
+					slog.String("sub", info.Subject),
+					slog.String("error", err.Error()),
+				)
 				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 
 				return
@@ -170,7 +175,7 @@ func (o *OIDCClient) marshalUserinfo(
 func (o *OIDCClient) SignOutHandler(c *echo.Context) error {
 	cookie, err := o.secureCookie.Encode("id_token", "")
 	if err != nil {
-		o.logger.ErrorContext(c.Request().Context(), "failed to encode id token", "error", err)
+		o.logger.ErrorContext(c.Request().Context(), "failed to encode id token", slog.String("error", err.Error()))
 		http.Error(c.Response(), "Internal Server Error", http.StatusInternalServerError)
 
 		return nil
@@ -212,7 +217,7 @@ func (o *OIDCClient) UserInfoHandler(c *echo.Context) error {
 	userInfo, err := o.userInfoFrom(c)
 	if err != nil {
 		if !errors.Is(err, ErrUnauthorized) {
-			o.logger.ErrorContext(c.Request().Context(), "failed to get user info", "error_message", err.Error())
+			o.logger.ErrorContext(c.Request().Context(), "failed to get user info", slog.String("error", err.Error()))
 		}
 
 		return c.JSON(http.StatusUnauthorized, "Unauthorized")
@@ -234,21 +239,17 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 
 	_, err := oidc.ParseToken(idToken, claims)
 	if err != nil {
-		o.logger.ErrorContext(c.Request().Context(), "failed to parse id_token", "error_message", err.Error())
+		o.logger.ErrorContext(c.Request().Context(), "failed to parse id_token", slog.String("error", err.Error()))
 		return nil, ErrUnauthorized
 	}
 
 	if claims.GetExpiration().Before(time.Now()) {
 		o.logger.Info(
 			"id_token is expired",
-			"expiration",
-			claims.GetExpiration().String(),
-			"email",
-			claims.Email,
-			"sub",
-			claims.Subject,
-			"session_id",
-			claims.SessionID,
+			slog.String("expiration", claims.GetExpiration().String()),
+			slog.String("email", claims.Email),
+			slog.String("sub", claims.Subject),
+			slog.String("session_id", claims.SessionID),
 		)
 
 		return nil, ErrUnauthorized
@@ -258,14 +259,10 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 	if refreshToken != "" && claims.GetExpiration().Before(time.Now().Add(15*time.Minute)) {
 		o.logger.Info(
 			"id_token is expiring soon, refreshing token",
-			"expiration",
-			claims.GetExpiration().String(),
-			"email",
-			claims.Email,
-			"sub",
-			claims.Subject,
-			"session_id",
-			claims.SessionID,
+			slog.String("expiration", claims.GetExpiration().String()),
+			slog.String("email", claims.Email),
+			slog.String("sub", claims.Subject),
+			slog.String("session_id", claims.SessionID),
 		)
 
 		assertion := ""
@@ -280,8 +277,7 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 				o.logger.ErrorContext(
 					c.Request().Context(),
 					"failed to create client assertion",
-					"error_message",
-					err.Error(),
+					slog.String("error", err.Error()),
 				)
 			}
 		}
@@ -294,7 +290,7 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 			oidc.ClientAssertionTypeJWTAssertion,
 		)
 		if err != nil {
-			o.logger.Error("failed to refresh token", "error_message", err.Error())
+			o.logger.Error("failed to refresh token", slog.String("error", err.Error()))
 			return nil, ErrUnauthorized
 		}
 
@@ -305,7 +301,7 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 
 		err = o.encodeTokenFrom(c, "id_token", tokens.IDToken, int(tokens.ExpiresIn))
 		if err != nil {
-			o.logger.Error("failed to encode refreshed id_token", "error_message", err.Error())
+			o.logger.Error("failed to encode refreshed id_token", slog.String("error", err.Error()))
 			return nil, ErrUnauthorized
 		}
 
@@ -313,14 +309,14 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 
 		_, err = oidc.ParseToken(idToken, claims)
 		if err != nil {
-			o.logger.Error("failed to parse id_token", "error_message", err.Error())
+			o.logger.Error("failed to parse id_token", slog.String("error", err.Error()))
 			return nil, ErrUnauthorized
 		}
 
 		if tokens.AccessToken != "" {
 			err := o.encodeTokenFrom(c, "access_token", tokens.AccessToken, int(tokens.ExpiresIn))
 			if err != nil {
-				o.logger.Error("failed to encode refreshed access_token", "error_message", err.Error())
+				o.logger.Error("failed to encode refreshed access_token", slog.String("error", err.Error()))
 				return nil, ErrUnauthorized
 			}
 
@@ -330,7 +326,7 @@ func (o *OIDCClient) userInfoFrom(c *echo.Context) (*UserInfo, error) {
 		if tokens.RefreshToken != "" {
 			err := o.encodeTokenFrom(c, "refresh_token", tokens.RefreshToken, refreshTokenCookieMaxAge)
 			if err != nil {
-				o.logger.Error("failed to encode refreshed refresh_token", "error_message", err.Error())
+				o.logger.Error("failed to encode refreshed refresh_token", slog.String("error", err.Error()))
 				return nil, ErrUnauthorized
 			}
 
@@ -361,7 +357,12 @@ func (o *OIDCClient) decodedTokenFrom(c *echo.Context, cookiename string) string
 
 	err = o.secureCookie.Decode(cookiename, cookie.Value, &decodedCookie)
 	if err != nil {
-		o.logger.Error("failed to decode cookie", "cookie_name", cookiename, "error", err)
+		o.logger.Error(
+			"failed to decode cookie",
+			slog.String("cookie_name", cookiename),
+			slog.String("error", err.Error()),
+		)
+
 		return ""
 	}
 
@@ -371,7 +372,7 @@ func (o *OIDCClient) decodedTokenFrom(c *echo.Context, cookiename string) string
 func (o *OIDCClient) encodeTokenFrom(c *echo.Context, cookiename, value string, expiresIn int) error {
 	encodedToken, err := o.secureCookie.Encode(cookiename, value)
 	if err != nil {
-		o.logger.Error("failed to encode id token", "error", err)
+		o.logger.Error("failed to encode id token", slog.String("error", err.Error()))
 		return errors.New("failed to encode id token")
 	}
 
@@ -393,7 +394,7 @@ func (o *OIDCClient) RequireLogin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c *echo.Context) error {
 		userInfo, err := o.userInfoFrom(c)
 		if err != nil {
-			o.logger.Error("failed to get user info", "error_message", err.Error())
+			o.logger.Error("failed to get user info", slog.String("error", err.Error()))
 			return c.JSON(http.StatusUnauthorized, "Unauthorized")
 		}
 
@@ -405,7 +406,7 @@ func (o *OIDCClient) RequireLogin(next echo.HandlerFunc) echo.HandlerFunc {
 			userInfo.IDToken,
 			o.rp.IDTokenVerifier(),
 		); err != nil {
-			o.logger.Error("ID token signature verification failed", "error", err)
+			o.logger.Error("ID token signature verification failed", slog.String("error", err.Error()))
 			return c.JSON(http.StatusUnauthorized, "Unauthorized")
 		}
 

--- a/server/options.go
+++ b/server/options.go
@@ -139,8 +139,8 @@ func registerAPIV2(s *Server, stack Stack, config apiV2Config) {
 	srv.SetRecoverFunc(func(ctx context.Context, p any) error {
 		opCtx := graphql.GetOperationContext(ctx)
 		slog.ErrorContext(ctx, "resolver panic",
-			"operation", opCtx.OperationName,
-			"panic", fmt.Sprintf("%v", p),
+			slog.String("operation", opCtx.OperationName),
+			slog.String("panic", fmt.Sprintf("%v", p)),
 		)
 
 		return fmt.Errorf("internal server error")
@@ -171,12 +171,12 @@ func logAndPresentError(ctx context.Context, e error) *gqlerror.Error {
 		errMsg = gqlErr.Message
 	}
 
-	attrs := []any{
-		"operation", opCtx.OperationName,
-		"error", errMsg,
+	attrs := []slog.Attr{
+		slog.String("operation", opCtx.OperationName),
+		slog.String("error", errMsg),
 	}
 	if fieldCtx != nil {
-		attrs = append(attrs, "path", fieldCtx.Path())
+		attrs = append(attrs, slog.String("path", fieldCtx.Path().String()))
 	}
 
 	// gqlgen emits this when DisableIntrospection is set; it is not a server error.
@@ -209,7 +209,7 @@ func logAndPresentError(ctx context.Context, e error) *gqlerror.Error {
 	case errors.Is(e, shared.ErrConflict):
 		code = "CONFLICT"
 	default:
-		slog.ErrorContext(ctx, "resolver error", attrs...)
+		slog.LogAttrs(ctx, slog.LevelError, "resolver error", attrs...)
 
 		return &gqlerror.Error{
 			Message:    "internal server error",
@@ -217,7 +217,7 @@ func logAndPresentError(ctx context.Context, e error) *gqlerror.Error {
 		}
 	}
 
-	slog.WarnContext(ctx, "resolver domain error", append(attrs, "code", code)...)
+	slog.LogAttrs(ctx, slog.LevelWarn, "resolver domain error", append(attrs, slog.String("code", code))...)
 
 	return &gqlerror.Error{Message: e.Error(), Extensions: map[string]any{"code": code}}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -43,7 +43,7 @@ func NewServer(opts ...Option) *Server {
 	for _, opt := range opts {
 		err := opt(s)
 		if err != nil {
-			s.logger.Error("failed to apply server option", "error", err)
+			s.logger.Error("failed to apply server option", slog.String("error", err.Error()))
 			return nil
 		}
 	}
@@ -82,7 +82,7 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 
 		err := s.Shutdown(ctx)
 		if err != nil {
-			s.logger.ErrorContext(ctx, "failed to shutdown server", "error", err)
+			s.logger.ErrorContext(ctx, "failed to shutdown server", slog.String("error", err.Error()))
 		}
 	}()
 
@@ -91,7 +91,7 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 		s.isShuttingDown.Store(true)
 	})
 
-	s.logger.InfoContext(ctx, "starting server", "address", s.Addr)
+	s.logger.InfoContext(ctx, "starting server", slog.String("address", s.Addr))
 
 	return s.Server.ListenAndServe()
 }


### PR DESCRIPTION
## Problem

Log attributes were passed as loose alternating key/value pairs (`slog.InfoContext(ctx, "msg", "incident_id", id)`).

The console handler stringifies arbitrary values automatically, so this looked fine locally. The OTel log bridge (`otelslog`) does not — a `slog.Value` of kind `Any` carrying a `uuid.UUID`, a domain ID type, or an `error` cannot be mapped onto an OTLP `AnyValue`, so those attributes lose their type or are dropped entirely once logs are exported to the collector.

The trigger case:

```go
// before — incident_id arrives at the collector untyped
slog.InfoContext(ctx, "incident automatically closed", "incident_id", id)

// after
slog.InfoContext(ctx, "incident automatically closed", slog.String("incident_id", id.String()))
```

## Changes

**Converted every `slog` call in the backend to typed `slog.Attr` constructors** — roughly 60 call sites across:

- `internal/core/service/` — incident, message, layer, feature, retention
- `internal/adapter/outbound/eventstore/` — postgres + inmem projectors, advisory lock, retention
- `internal/adapter/outbound/queries/` — postgres + inmem read-model queries
- `internal/cli/` — migrate, serve, stack
- `server/` — server, options, `auth/oidc.go`

Mapping applied:

| Value | Attribute |
| --- | --- |
| `uuid.UUID`, domain IDs, anything with `String()` | `slog.String(k, v.String())` |
| `error` | `slog.String("error", err.Error())` |
| named string types (`shared.TriageStatus`, goose `MigrationType`) | `slog.String(k, string(v))` |
| `int` / `int64` / `uint` | `slog.Int` / `slog.Int64` / `slog.Uint64` |
| `time.Time` / `time.Duration` | `slog.String(k, t.Format(time.RFC3339))` / `slog.Duration` |
| `[]string` | `strings.Join(...)` into a `slog.String` |

No `slog.Any` fallbacks were needed.

**Signature changes that make this enforceable by the compiler:**

- `logIfUnexpected` (`internal/core/service/assertions.go`) now takes `...slog.Attr` instead of `...any` and logs via `slog.LogAttrs`. Every service call site is now type-checked.
- `logAndPresentError` (`server/options.go`) builds `[]slog.Attr` instead of `[]any` and logs via `slog.LogAttrs`, since a `[]slog.Attr` cannot be spread into the `...any` parameter of `ErrorContext`/`WarnContext`.

**Key normalisation:** `server/auth/oidc.go` used `"error.message"` and `"error_message"` in nine places; all error keys are now `error`, consistent with the rest of the codebase and with `sloglint`'s `key-naming-case: snake`.

## Prevention

`sloglint` was already enabled, but without the option that catches this. Added `attr-only: true` to `.golangci.yaml`, which rejects any `slog` call using loose key/value pairs. CI now fails on regressions.

## Docs

`AGENTS.md` gains an **"Always use typed `slog.Attr` constructors"** section with the mapping table above, the `slog.LogAttrs` rule for conditionally assembled attribute slices, and updated examples throughout the logging section (the previous examples demonstrated the wrong pattern).

## Verification

```
golangci-lint fmt ./...   # clean
golangci-lint run ./...   # 0 issues
go test ./...             # all pass
```

No behavioural change: messages, levels, and control flow are untouched.
