### PR TITLE
feat(server): add TLS support with optional ACME certificates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.22.0
 	go.opentelemetry.io/otel/sdk/metric v1.46.0
 	go.opentelemetry.io/otel/trace v1.46.0
+	golang.org/x/crypto v0.56.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 go.yaml.in/yaml/v3 v3.0.5 h1:N6y/pJk8buWs9NY5ERU2HSMfm+IuD/OtfdAnq6kESPw=
 go.yaml.in/yaml/v3 v3.0.5/go.mod h1:HVTZu1O7/Vkt2N+BFy8Zza+lnLsABggaTM2ZpNIGuKg=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/mod v0.40.0 h1:hUv+3cXcdRHz08UmSiOob7sadHig73uo5bkXxQ/tvUs=
 golang.org/x/mod v0.40.0/go.mod h1:0/weTWkPWGBikyTWAX3dkjVztMmBA5hM0DH6BElSupE=
 golang.org/x/net v0.58.0 h1:ynWG7rqYi4ccpTEuPZ2QGWHktVEM9DMCj9yzDE0Q7To=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -55,6 +55,18 @@ func boolOption(name string, defaultValue bool, description string, legacyEnv ..
 	}
 }
 
+func stringSliceOption(name string, defaultValue []string, description string, legacyEnv ...string) configOption {
+	return configOption{
+		name:        name,
+		value:       defaultValue,
+		description: description,
+		legacyEnv:   legacyEnv,
+		addFlag: func(flags *pflag.FlagSet) {
+			flags.StringSlice(name, defaultValue, description)
+		},
+	}
+}
+
 var rootConfigOptions = []configOption{
 	stringOption("log-level", "info", "Log level (debug, info, warn, error)", "LOG_LEVEL"),
 	stringOption("database-url", "", "PostgreSQL connection string (DSN or URL)", "DATABASE_URL"),

--- a/internal/cli/serve.go
+++ b/internal/cli/serve.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -42,6 +43,51 @@ var serveConfigOptions = []configOption{
 		"GRAPHQL_INTROSPECTION",
 	),
 	boolOption("migrate-on-startup", false, "Run database migrations before starting the server", "MIGRATE_ON_STARTUP"),
+	stringOption("tls-cert", "", "Path to a PEM certificate; enables HTTPS together with --tls-key", "TLS_CERT"),
+	stringOption("tls-key", "", "Path to the PEM private key matching --tls-cert", "TLS_KEY"),
+	stringSliceOption(
+		"acme-domains",
+		nil,
+		"Hostnames to obtain a Let's Encrypt certificate for; enables ACME and requires --port 443",
+	),
+	stringOption("acme-email", "", "Contact address registered with the ACME CA for expiry notices"),
+	stringOption("acme-cache-dir", "/var/lib/sitrep/acme", "Directory persisting ACME account keys and certificates"),
+	stringOption("acme-directory-url", "", "ACME directory URL; empty uses Let's Encrypt production"),
+}
+
+// splitList accepts a repeated flag, a comma-separated string, or a YAML list,
+// so the same value works from the command line, the environment and the file.
+func splitList(values []string) []string {
+	out := make([]string, 0, len(values))
+
+	for _, value := range values {
+		for part := range strings.SplitSeq(value, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+	}
+
+	return out
+}
+
+// tlsOptions returns the TLS server option, or nothing when the server should
+// serve plain HTTP behind a terminating proxy.
+func tlsOptions(v *viper.Viper) []server.Option {
+	cfg := server.TLSConfig{
+		CertFile:         v.GetString("tls-cert"),
+		KeyFile:          v.GetString("tls-key"),
+		ACMEDomains:      splitList(v.GetStringSlice("acme-domains")),
+		ACMEEmail:        v.GetString("acme-email"),
+		ACMECacheDir:     v.GetString("acme-cache-dir"),
+		ACMEDirectoryURL: v.GetString("acme-directory-url"),
+	}
+
+	if cfg.CertFile == "" && cfg.KeyFile == "" && len(cfg.ACMEDomains) == 0 {
+		return nil
+	}
+
+	return []server.Option{server.WithTLS(cfg)}
 }
 
 func newServeCmd(v *viper.Viper) (*cobra.Command, error) {
@@ -109,6 +155,7 @@ func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 		server.WithVersion(Version, Sha),
 		server.WithApiV2(s.Stack, apiOpts...),
 	}
+	opts = append(opts, tlsOptions(v)...)
 
 	if v.GetString("oidc-client-id") != "" {
 		oidcClient, err := auth.NewOIDC(ctx,
@@ -132,7 +179,12 @@ func runServe(cmd *cobra.Command, _ []string, v *viper.Viper) error {
 		slog.WarnContext(ctx, "OIDC client not configured, using local enforcer")
 	}
 
-	srv := server.NewServer(opts...)
+	srv, err := server.NewServer(opts...)
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to configure server", slog.String("error", err.Error()))
+		return err
+	}
+
 	if err := srv.ListenAndServe(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		slog.ErrorContext(ctx, "failed to start server", slog.String("error", err.Error()))
 		return err

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -31,10 +31,12 @@ func TestShutdownSignals(t *testing.T) {
 }
 
 func TestAPIV2UsesFinalEnforcer(t *testing.T) {
-	s := NewServer(
+	s, err := NewServer(
 		WithApiV2(Stack{}),
 		WithEnforcer(rejectingEnforcer{}),
 	)
+	require.NoError(t, err)
+
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/health", nil)
 	s.router.ServeHTTP(rec, req)
@@ -115,7 +117,8 @@ func TestBuildInfoWithoutVersionOption(t *testing.T) {
 // exact response guards against a regression back to the SPA fallback serving index.html,
 // which is what a JSON-parsing old client chokes on.
 func TestLegacyGraphQLGone(t *testing.T) {
-	s := NewServer()
+	s, err := NewServer()
+	require.NoError(t, err)
 
 	for _, path := range []string{"/v1/graphql", "/v1/graphql/ws"} {
 		t.Run(path, func(t *testing.T) {
@@ -142,7 +145,8 @@ func TestLegacyGraphQLGone(t *testing.T) {
 // middleware answers 500, whereas a real build answers 200. Either way, this route isn't
 // legacyGraphQLGone, which is the only thing worth asserting here.
 func TestUnrelatedUnmatchedPathStillFallsBackToSPA(t *testing.T) {
-	s := NewServer()
+	s, err := NewServer()
+	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/some/unknown/route", nil)

--- a/server/server.go
+++ b/server/server.go
@@ -28,10 +28,11 @@ type Server struct {
 	auth.Enforcer
 	router        *echo.Echo
 	registerAPIV2 func()
+	tls           *TLSConfig
 	*http.Server
 }
 
-func NewServer(opts ...Option) *Server {
+func NewServer(opts ...Option) (*Server, error) {
 	s := &Server{
 		logger:   slog.Default().WithGroup("server"),
 		port:     8081,
@@ -41,10 +42,8 @@ func NewServer(opts ...Option) *Server {
 	}
 
 	for _, opt := range opts {
-		err := opt(s)
-		if err != nil {
-			s.logger.Error("failed to apply server option", slog.String("error", err.Error()))
-			return nil
+		if err := opt(s); err != nil {
+			return nil, fmt.Errorf("apply server option: %w", err)
 		}
 	}
 
@@ -62,7 +61,7 @@ func NewServer(opts ...Option) *Server {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	return s
+	return s, nil
 }
 
 func shutdownSignals() []os.Signal { return []os.Signal{os.Interrupt, syscall.SIGTERM} }
@@ -93,7 +92,7 @@ func (s *Server) ListenAndServe(ctx context.Context) error {
 
 	s.logger.InfoContext(ctx, "starting server", slog.String("address", s.Addr))
 
-	return s.Server.ListenAndServe()
+	return s.listenAndServe()
 }
 
 func cacheControlMiddleWare(next echo.HandlerFunc) echo.HandlerFunc {

--- a/server/tls.go
+++ b/server/tls.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/crypto/acme"
+	"golang.org/x/crypto/acme/autocert"
+)
+
+// acmeTLSPort is the only port on which a TLS-ALPN-01 challenge is accepted.
+// Let's Encrypt always connects to it, regardless of the port the server binds.
+const acmeTLSPort = 443
+
+// TLSConfig selects how the server obtains its certificate. Exactly one of the
+// two modes must be configured: a static key pair, or ACME.
+type TLSConfig struct {
+	// CertFile and KeyFile point at a PEM key pair managed outside the server.
+	CertFile string
+	KeyFile  string
+
+	// ACMEDomains enables ACME when non-empty. Certificates are issued for
+	// these hostnames only.
+	ACMEDomains []string
+	// ACMEEmail is registered with the CA for expiry notices. Optional.
+	ACMEEmail string
+	// ACMECacheDir persists account keys and certificates across restarts.
+	// Without it every restart requests a new certificate and will hit the
+	// CA's rate limits.
+	ACMECacheDir string
+	// ACMEDirectoryURL overrides the CA. Empty means Let's Encrypt production;
+	// point it at the staging directory while testing.
+	ACMEDirectoryURL string
+}
+
+func (c TLSConfig) usesACME() bool { return len(c.ACMEDomains) > 0 }
+
+func (c TLSConfig) validate(port uint) error {
+	hasKeyPair := c.CertFile != "" || c.KeyFile != ""
+
+	switch {
+	case hasKeyPair && c.usesACME():
+		return errors.New("tls: acme-domains cannot be combined with tls-cert/tls-key")
+	case !hasKeyPair && !c.usesACME():
+		return errors.New("tls: either tls-cert and tls-key, or acme-domains must be set")
+	case hasKeyPair && (c.CertFile == "" || c.KeyFile == ""):
+		return errors.New("tls: tls-cert and tls-key must be set together")
+	}
+
+	if !c.usesACME() {
+		return nil
+	}
+
+	if c.ACMECacheDir == "" {
+		return errors.New("tls: acme-cache-dir is required so certificates survive a restart")
+	}
+
+	if !filepath.IsAbs(c.ACMECacheDir) {
+		return fmt.Errorf("tls: acme-cache-dir must be an absolute path, got %q", c.ACMECacheDir)
+	}
+
+	// TLS-ALPN-01 is the only challenge type served, and the CA always dials 443.
+	if port != acmeTLSPort {
+		return fmt.Errorf("tls: acme requires port %d, got %d", acmeTLSPort, port)
+	}
+
+	return nil
+}
+
+// WithTLS serves HTTPS instead of HTTP.
+func WithTLS(cfg TLSConfig) Option {
+	return func(s *Server) error {
+		if err := cfg.validate(s.port); err != nil {
+			return err
+		}
+
+		s.tls = &cfg
+
+		return nil
+	}
+}
+
+// autocertManager builds the certificate manager for ACME mode. The returned
+// tls.Config answers TLS-ALPN-01 challenges on the listening socket, so no
+// separate HTTP-01 listener on port 80 is needed.
+func (c TLSConfig) autocertManager() *autocert.Manager {
+	m := &autocert.Manager{
+		Prompt:     autocert.AcceptTOS,
+		HostPolicy: autocert.HostWhitelist(c.ACMEDomains...),
+		Cache:      autocert.DirCache(c.ACMECacheDir),
+		Email:      c.ACMEEmail,
+	}
+
+	if c.ACMEDirectoryURL != "" {
+		m.Client = &acme.Client{DirectoryURL: c.ACMEDirectoryURL}
+	}
+
+	return m
+}
+
+// listenAndServe starts the server in the configured mode.
+func (s *Server) listenAndServe() error {
+	if s.tls == nil {
+		return s.Server.ListenAndServe()
+	}
+
+	if !s.tls.usesACME() {
+		return s.ListenAndServeTLS(s.tls.CertFile, s.tls.KeyFile)
+	}
+
+	manager := s.tls.autocertManager()
+
+	tlsConfig := manager.TLSConfig()
+	tlsConfig.MinVersion = tls.VersionTLS12
+	s.TLSConfig = tlsConfig
+
+	// Paths are already in TLSConfig.GetCertificate.
+	return s.ListenAndServeTLS("", "")
+}

--- a/server/tls_test.go
+++ b/server/tls_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithTLSValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    uint
+		cfg     TLSConfig
+		wantErr string
+	}{
+		{
+			name: "static key pair",
+			port: 4180,
+			cfg:  TLSConfig{CertFile: "/tls/cert.pem", KeyFile: "/tls/key.pem"},
+		},
+		{
+			name: "acme on 443",
+			port: acmeTLSPort,
+			cfg:  TLSConfig{ACMEDomains: []string{"sitrep.example.org"}, ACMECacheDir: "/var/lib/sitrep/acme"},
+		},
+		{
+			name:    "key pair and acme are mutually exclusive",
+			port:    acmeTLSPort,
+			cfg:     TLSConfig{CertFile: "/tls/cert.pem", KeyFile: "/tls/key.pem", ACMEDomains: []string{"a.example"}},
+			wantErr: "cannot be combined",
+		},
+		{
+			name:    "cert without key",
+			port:    4180,
+			cfg:     TLSConfig{CertFile: "/tls/cert.pem"},
+			wantErr: "must be set together",
+		},
+		{
+			name:    "nothing configured",
+			port:    4180,
+			cfg:     TLSConfig{},
+			wantErr: "must be set",
+		},
+		{
+			name:    "acme without cache dir",
+			port:    acmeTLSPort,
+			cfg:     TLSConfig{ACMEDomains: []string{"a.example"}},
+			wantErr: "acme-cache-dir is required",
+		},
+		{
+			name:    "acme with relative cache dir",
+			port:    acmeTLSPort,
+			cfg:     TLSConfig{ACMEDomains: []string{"a.example"}, ACMECacheDir: "acme"},
+			wantErr: "absolute path",
+		},
+		{
+			name:    "acme on a port other than 443",
+			port:    4180,
+			cfg:     TLSConfig{ACMEDomains: []string{"a.example"}, ACMECacheDir: "/var/lib/sitrep/acme"},
+			wantErr: "acme requires port 443",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{port: tc.port}
+
+			err := WithTLS(tc.cfg)(s)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				assert.Nil(t, s.tls)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, s.tls)
+		})
+	}
+}
+
+func TestAutocertManagerUsesConfiguredDirectory(t *testing.T) {
+	cfg := TLSConfig{
+		ACMEDomains:      []string{"sitrep.example.org"},
+		ACMECacheDir:     "/var/lib/sitrep/acme",
+		ACMEEmail:        "ops@example.org",
+		ACMEDirectoryURL: "https://acme-staging-v02.api.letsencrypt.org/directory",
+	}
+
+	m := cfg.autocertManager()
+
+	require.NotNil(t, m.Client)
+	assert.Equal(t, cfg.ACMEDirectoryURL, m.Client.DirectoryURL)
+	assert.Equal(t, cfg.ACMEEmail, m.Email)
+	require.NoError(t, m.HostPolicy(t.Context(), "sitrep.example.org"))
+	assert.Error(t, m.HostPolicy(t.Context(), "attacker.example.org"))
+}


### PR DESCRIPTION
Lets the server terminate TLS itself instead of always requiring a reverse proxy in front of it.

## Modes

`WithTLS` takes a `TLSConfig` with two mutually exclusive modes:

```go
server.WithTLS(server.TLSConfig{
    CertFile: "/etc/sitrep/tls/cert.pem",   // static key pair
    KeyFile:  "/etc/sitrep/tls/key.pem",
})

server.WithTLS(server.TLSConfig{
    ACMEDomains:  []string{"sitrep.example.org"},   // Let's Encrypt
    ACMEEmail:    "ops@example.org",
    ACMECacheDir: "/var/lib/sitrep/acme",
})
```

Leaving both unset keeps the current behaviour — plain HTTP, proxy terminates TLS. `ListenAndServe` dispatches through `listenAndServe()`, which picks `ListenAndServe`, `ListenAndServeTLS(cert, key)`, or the autocert path.

## Why TLS-ALPN-01 and not HTTP-01

ACME uses the **TLS-ALPN-01** challenge. `autocert.Manager.TLSConfig()` answers it on the listening socket itself, so there is no second listener on port 80 and no extra firewall hole.

The trade-off is that the CA always dials **443** for this challenge type. Rather than letting that fail opaquely during issuance, the config rejects any other port at startup:

```
Error: apply server option: tls: acme requires port 443, got 4180
```

`MinVersion` is pinned to TLS 1.2.

## Validation

`acme-cache-dir` is mandatory and must be absolute. Without persistence every restart requests a fresh certificate and walks straight into the CA's rate limits — a failure mode that only shows up in production, so it is rejected up front. Also rejected: a key pair combined with ACME, `tls-cert` without `tls-key`, and a TLS config with neither mode set. Each case has a table-driven test in `server/tls_test.go`.

## Config options

New on `serve`: `tls-cert`, `tls-key`, `acme-domains`, `acme-email`, `acme-cache-dir` (default `/var/lib/sitrep/acme`), `acme-directory-url` (empty = Let's Encrypt production; point it at the staging directory while testing).

`acme-domains` is the first list-valued option, so `stringSliceOption` joins the existing helpers in `internal/cli/root.go`. Viper resolves list values differently per source — a YAML list yields a slice, but an env var yields a string that `GetStringSlice` splits on *whitespace*, not commas. `splitList` normalises all three sources so `--acme-domains a.example,b.example`, `SITREP_ACME_DOMAINS=a.example,b.example` and a YAML list behave identically.

## Drive-by fix: `NewServer` returned `nil` on error

`NewServer` logged a failed option and returned `nil`, and `runServe` then called `ListenAndServe` on it — a nil dereference. Previously unreachable in practice; the TLS option makes it reachable from a config typo.

```go
func NewServer(opts ...Option) (*Server, error)
```

The compiler now forces every caller to handle it, and the underlying reason reaches the operator as the process exit error rather than only a log line. Four call sites (one production, three tests) updated.

## Not included

The packaged systemd unit and sample config (`LoadCredential` wiring for a static key pair, `CAP_NET_BIND_SERVICE` for port 443, ACME cache under `StateDirectory`) are part of the deb/rpm packaging work and will land with that change.

## Verification

```
golangci-lint fmt ./...   # clean
golangci-lint run ./...   # 0 issues
go test ./...             # all pass
```

Manually exercised the new flags: validation errors for ACME on the wrong port and for `tls-cert` without `tls-key`, and comma-separated domain parsing.

New direct dependency: `golang.org/x/crypto` (was already an indirect dependency).
