### PR TITLE
chore(ci): run the Go gates on every path, including releases

### DIFF
--- a/.github/workflows/docker-workflow.yml
+++ b/.github/workflows/docker-workflow.yml
@@ -42,35 +42,6 @@ jobs:
       - name: Install Go dependencies
         run: go mod download
 
-      - name: Install Go Linter
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          install-only: true
-          version: v2.13.2
-
-      - name: Go Format
-        run: golangci-lint fmt ./...
-
-      - name: Go Lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
-        with:
-          version: v2.13.2
-          args: --timeout=5m ./...
-
-      - name: Go Test
-        run: go test -coverprofile=go-coverage.out ./...
-
-      - name: Convert Go coverage to Cobertura
-        run: |
-          go install github.com/boumenot/gocover-cobertura@4afa1205ab3b54ae098dd4724c1657aad10f7484
-          gocover-cobertura < go-coverage.out > go-cobertura.xml
-
-      - name: Upload Go coverage artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-report-go
-          path: go-cobertura.xml
-
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0

--- a/.github/workflows/go-workflow.yml
+++ b/.github/workflows/go-workflow.yml
@@ -1,29 +1,21 @@
-name: Automated Tests and Linting
+name: Go Build & Test
 
-# Tests and linting only — deliberately no coverage upload.
-#
-# upload-code-coverage can only attach a report to a pull request or the default branch.
-# This workflow runs on push to every branch except main/develop, so before a PR exists
-# there is nothing to attach to and the upload fails with
-#   HTTP 400: Only default branch is allowed if no pull_request_number is provided
-# (which is why re-running after opening the PR used to fix it). Once a PR does exist,
-# main.yml runs on the pull_request event — which fires on every push to the head branch —
-# and uploads both reports with a proper PR number, so uploading here only duplicated it.
-permissions: read-all
 on:
-  push:
-    branches-ignore:
-      - "main"
-      - "develop"
+  workflow_call:
+    inputs:
+      coverage:
+        description: "Whether to produce and upload the coverage artifact"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
 jobs:
-  ui-tests:
-    name: "UI Tests Only"
-    uses: ./.github/workflows/ui-workflow.yml
-    with:
-      build: false
-  go-tests:
+  go:
     runs-on: ubuntu-latest
-    name: "Go Tests"
+    name: "Go Lint and Test"
     permissions:
       contents: read
     services:
@@ -50,21 +42,43 @@ jobs:
         with:
           go-version: "stable"
 
+      # ui.Assets embeds ui/build, so the packages fail to compile without it.
+      # A placeholder keeps this job independent of the UI build, so the two run
+      # in parallel; nothing here asserts on the served assets.
       - name: Create placeholder UI build dir
         run: mkdir -p ui/build && echo "placeholder" > ui/build/placeholder
 
       - name: Install Go dependencies
         run: go mod download
 
+      - name: Install Go Linter
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          install-only: true
+          version: v2.13.2
+
+      # --diff reports and fails; a bare `fmt` rewrites the checkout and exits 0,
+      # which never fails a build.
+      - name: Go Format
+        run: golangci-lint fmt --diff ./...
+
+      - name: Go Lint
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        with:
+          version: v2.13.2
+          args: --timeout=5m ./...
+
       - name: Go Test
         run: go test -coverprofile=go-coverage.out ./...
 
       - name: Convert Go coverage to Cobertura
+        if: inputs.coverage
         run: |
           go install github.com/boumenot/gocover-cobertura@4afa1205ab3b54ae098dd4724c1657aad10f7484
           gocover-cobertura < go-coverage.out > go-cobertura.xml
 
       - name: Upload Go coverage artifact
+        if: inputs.coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report-go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,11 @@ jobs:
     uses: ./.github/workflows/ui-workflow.yml
     with:
       build: true
-  
+
+  go-build:
+    name: "Go Lint and Test"
+    uses: ./.github/workflows/go-workflow.yml
+
   docker-build:
     name: "Build and Push Sitrep Image"
     needs: ui-build  # Only depends on UI, not on hasura
@@ -87,14 +91,14 @@ jobs:
           label: code-coverage-agent
 
   upload-coverage-go:
-    needs: docker-build
+    needs: go-build
     # Coverage attaches to a pull request or the default branch. This workflow also
     # runs on v* tag pushes, which are neither — upload-code-coverage rejects those
     # with "Only default branch is allowed if no pull_request_number is provided", so
     # skip them rather than fail the release run.
     if: >-
       ${{ !cancelled()
-      && needs.docker-build.result == 'success'
+      && needs.go-build.result == 'success'
       && (github.event_name != 'pull_request'
           || github.event.pull_request.head.repo.full_name == github.repository)
       && (github.event_name == 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,19 @@ jobs:
     with:
       build: true
 
+  # A tag is normally cut from a develop commit that main.yml already tested,
+  # but nothing guarantees it: the tag push and the branch push race, and a tag
+  # can be placed on any commit. Re-running the gates here is what actually
+  # blocks a broken release from publishing.
+  go-build:
+    name: Lint and test Go
+    uses: ./.github/workflows/go-workflow.yml
+    with:
+      coverage: false
+
   release:
     name: Create GitHub release
-    needs: ui-build
+    needs: [ui-build, go-build]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## The problem

`release.yml` built and published without ever running the Go lint/test suite. It ran the UI job — which lints, typechecks and tests — and then went straight to GoReleaser.

The tagged commit *was* usually tested: the prepare commit lands on `develop` and `main.yml` runs there. But nothing **blocked** on it:

- `main.yml` triggers on `push: branches`, so a tag push doesn't run it.
- `scripts/release.sh` pushes the branch and the tag back to back, so the two workflows race — the release can publish before the tests finish, and a red test won't stop it.
- A tag can be placed on any commit (a hotfix branch, `--version` on an older commit), in which case it was never tested at all.

## The change

Extracts the Go gates from `docker-workflow.yml` into a reusable `go-workflow.yml`, called from both `main.yml` and `release.yml`, where the `release` job now `needs` it.

```
main.yml     ui-build → ui-workflow     go-build → go-workflow
             docker-build → docker-workflow (needs ui-build)
             upload-coverage-go (needs go-build)

release.yml  ui-build → ui-workflow     go-build → go-workflow
             release (needs [ui-build, go-build])   ← the gate
```

`docker-workflow.yml` is left doing only what its name says. Calling it wholesale from `release.yml` to get the gates would have pushed the image **twice** — once via `ko build`, once via GoReleaser's `kos`.

The job creates a placeholder `ui/build` rather than consuming the `ui-build` artifact. `ui.Assets` embeds that directory so the packages won't compile without *something* there, and the placeholder keeps the job independent of the UI build so the two run in parallel. This mirrors what `build.yaml` already did, and no Go test asserts on the served assets.

## Drops `build.yaml`

Once a PR is open, `main.yml`'s `pull_request` trigger fires on **every push to the head branch**, so `build.yaml` duplicated a full UI + Go run on each one — two complete CI runs per push.

Its only unique contribution was CI on branches with no PR yet. A draft PR covers that, and `main.yml` already gates the publishing steps appropriately (the flipt bundle push is `develop`-only, the image push is `event_name != 'pull_request'`, both coverage uploads are conditioned).

Per push with a PR open: **2 workflow runs → 1**.

## Two bugs fixed along the way

**The format gate could never fail.** `docker-workflow.yml` ran:

```yaml
- name: Go Format
  run: golangci-lint fmt ./...
```

Tested against a deliberately misformatted file, this **rewrites the checkout and exits 0**. It has never been able to fail a build. The reusable workflow uses `golangci-lint fmt --diff ./...`, which exits 1.

**`upload-coverage-go` depended on the wrong job.** It needed `docker-build` — the image build — rather than the job that produces the coverage artifact. Now needs `go-build`.

## ⚠️ Ruleset change required before merging

The `main` ruleset (`6490346`) requires the context `UI Tests Only / UI Test and Build`, which only `build.yaml` produced. **That context must be removed from the ruleset**, or PRs into `main` will wait forever on a check that can never report.

Worth noting it was already partly broken: `build.yaml` ignored pushes to `main`/`develop`, so a `develop → main` PR never produced that check either.

## Also worth deciding

Neither ruleset requires **any** Go check today — both only require the UI job. So the gates consolidated here still can't block a merge. To enforce them, add to the `develop` and `main` rulesets:

```
Go Lint and Test / Go Lint and Test
```

## Verification

All 10 remaining workflow files parse, and the resulting job graph was checked programmatically. No repository settings were changed by this PR.
