### PR TITLE
fix(admin): group UI polish — duplicate count, name wrapping, 64-char limit

### DIFF
--- a/internal/core/domain/access/group.go
+++ b/internal/core/domain/access/group.go
@@ -69,6 +69,10 @@ func (g *AccessGroup) Create(name, description, actor string, at time.Time) erro
 		return fmt.Errorf("group name must not be empty")
 	}
 
+	if len(name) > 64 {
+		return fmt.Errorf("group name must not exceed 64 characters")
+	}
+
 	eventsourcing.TrackChange(g, GroupCreated{Name: name, Description: description}, at, meta(actor))
 
 	return nil
@@ -81,6 +85,10 @@ func (g *AccessGroup) Rename(name, actor string, at time.Time) error {
 
 	if strings.TrimSpace(name) == "" {
 		return fmt.Errorf("group name must not be empty")
+	}
+
+	if len(name) > 64 {
+		return fmt.Errorf("group name must not exceed 64 characters")
 	}
 
 	if g.name == name {

--- a/ui/src/views/admin/AdminLayout.tsx
+++ b/ui/src/views/admin/AdminLayout.tsx
@@ -37,6 +37,7 @@ function AdminLayout() {
                         <NavLink
                           to={`groups/${group.id}`}
                           className={group.id === groupId ? "is-active" : ""}
+                          style={{ whiteSpace: "normal", wordBreak: "break-word" }}
                         >
                           {group.name}
                         </NavLink>

--- a/ui/src/views/admin/GroupDetail.tsx
+++ b/ui/src/views/admin/GroupDetail.tsx
@@ -150,6 +150,7 @@ function GroupDetail() {
                 className="input"
                 placeholder={t("adminGroupDetail.groupNamePlaceholder")}
                 autoFocus
+                maxLength={64}
                 value={renameValue}
                 onChange={(e) => setRenameValue(e.target.value)}
                 onKeyDown={(e) => {

--- a/ui/src/views/admin/GroupDetail.tsx
+++ b/ui/src/views/admin/GroupDetail.tsx
@@ -147,7 +147,7 @@ function GroupDetail() {
           <div className="field has-addons mb-1">
             <div className="control is-expanded">
               <input
-                className="input"
+                className={`input${renameValue.length === 64 ? " is-danger" : ""}`}
                 placeholder={t("adminGroupDetail.groupNamePlaceholder")}
                 autoFocus
                 maxLength={64}
@@ -158,6 +158,11 @@ function GroupDetail() {
                   if (e.key === "Escape") setIsRenaming(false);
                 }}
               />
+              {renameValue.length >= 54 && (
+                <p className={`help${renameValue.length === 64 ? " is-danger" : " is-warning"}`}>
+                  {64 - renameValue.length} / 64
+                </p>
+              )}
             </div>
             <div className="control">
               <button

--- a/ui/src/views/admin/Groups.tsx
+++ b/ui/src/views/admin/Groups.tsx
@@ -151,7 +151,7 @@ function Groups() {
             className="button is-ghost is-small has-text-grey px-0"
             onClick={() => setShowArchived(!showArchived)}
           >
-            {showArchived ? "▾" : "▸"}&ensp;{t("adminGroups.archived", { count: archivedGroups.length })} ({archivedGroups.length})
+            {showArchived ? "▾" : "▸"}&ensp;{t("adminGroups.archived", { count: archivedGroups.length })}
           </button>
           {showArchived && (
             <div className="table-container mt-2">

--- a/ui/src/views/admin/Groups.tsx
+++ b/ui/src/views/admin/Groups.tsx
@@ -74,7 +74,7 @@ function Groups() {
             <div className="control">
               <input
                 id="group-name"
-                className="input"
+                className={`input${name.length === 64 ? " is-danger" : ""}`}
                 autoFocus
                 maxLength={64}
                 value={name}
@@ -85,6 +85,11 @@ function Groups() {
                 }}
               />
             </div>
+            {name.length >= 54 && (
+              <p className={`help${name.length === 64 ? " is-danger" : " is-warning"}`}>
+                {64 - name.length} / 64
+              </p>
+            )}
           </div>
           <div className="field">
             <label className="label" htmlFor="group-description">

--- a/ui/src/views/admin/Groups.tsx
+++ b/ui/src/views/admin/Groups.tsx
@@ -76,6 +76,7 @@ function Groups() {
                 id="group-name"
                 className="input"
                 autoFocus
+                maxLength={64}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 onKeyDown={(e) => {


### PR DESCRIPTION
## Summary

Three small fixes to the admin Groups pages:

- **Duplicate archived count removed:** The archived groups toggle showed `"Archiviert (2) (2)"` because the i18n key already interpolates the count and a manual `({archivedGroups.length})` was appended on top.

- **Long group names now wrap in the sidebar menu:** Bulma's menu anchor applies `white-space: nowrap` by default, causing long names to overflow. Fixed with `whiteSpace: "normal"` and `wordBreak: "break-word"` on the NavLink.

- **Group names capped at 64 characters:** `maxLength={64}` added to both the create (Groups.tsx) and rename (GroupDetail.tsx) inputs. Matching server-side validation added to `AccessGroup.Create` and `AccessGroup.Rename` in the domain model.

## Test plan

- [x] Create a group — typing stops at 64 characters
- [x] Rename a group — typing stops at 64 characters
- [x] Archive 2+ groups — toggle shows `"Archiviert (2)"` not `"Archiviert (2) (2)"`
- [x] Create a group with a very long name — wraps in the left-hand menu instead of overflowing