### PR TITLE
fix(ui): show FontAwesome spinner on service worker update button

### DIFF
--- a/ui/src/utils/ReloadSWPrompt.tsx
+++ b/ui/src/utils/ReloadSWPrompt.tsx
@@ -1,6 +1,8 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { t } from "i18next";
 import { useEffect, useId, useRef, useState } from "react";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { createSWChannel, now, type SWMessage } from "./swUpdateChannel";
 import {
   CURRENT_SHA,
@@ -270,10 +272,11 @@ export function ReloadPrompt() {
               <div className="buttons pt-2">
                 <button
                   type="button"
-                  className={`button is-success is-small${reloading ? " is-loading" : ""}`}
+                  className="button is-success is-small"
                   onClick={handleReloadNow}
                   disabled={reloading}
                 >
+                  {reloading && <FontAwesomeIcon icon={faSpinner} spin className="mr-2" />}
                   {t("reloadNow")}
                 </button>
                 <button

--- a/ui/src/utils/ReloadSWPrompt.tsx
+++ b/ui/src/utils/ReloadSWPrompt.tsx
@@ -218,7 +218,10 @@ export function ReloadPrompt() {
     }
   };
 
+  const [reloading, setReloading] = useState(false);
+
   const handleReloadNow = () => {
+    setReloading(true);
     channelRef.current?.post({ type: "apply-now", tabId });
     updateServiceWorker(true);
   };
@@ -267,8 +270,9 @@ export function ReloadPrompt() {
               <div className="buttons pt-2">
                 <button
                   type="button"
-                  className="button is-success is-small"
+                  className={`button is-success is-small${reloading ? " is-loading" : ""}`}
                   onClick={handleReloadNow}
+                  disabled={reloading}
                 >
                   {t("reloadNow")}
                 </button>


### PR DESCRIPTION
## Summary

- When the user clicks "Update Now" on the service worker update notification, the button now shows a spinning `faSpinner` icon next to the label and becomes disabled while the reload is in progress.
- Replaces the initial Bulma `is-loading` approach (which hides the button text via a `::after` pseudo-element) with a FontAwesome `faSpinner spin` — the label stays visible alongside the spinner, consistent with the pattern used elsewhere in the app (e.g. rename/save buttons in GroupDetail).

## Test plan

- [x] Trigger a service worker update notification
- [x] Click "Update Now" — spinner appears next to the label, button is disabled
- [x] Page reloads shortly after