### PR TITLE
feat(map): add scrim layer for satellite basemap dimming

### DIFF
--- a/ui/src/assets/map/styles/ch.swisstopo.leichte-basiskarte-imagery.vt.json
+++ b/ui/src/assets/map/styles/ch.swisstopo.leichte-basiskarte-imagery.vt.json
@@ -154,6 +154,17 @@
       "source": "swissimage_wmts"
     },
     {
+      "id": "satellite-mute-scrim",
+      "type": "background",
+      "paint": {
+        "background-color": "#ffffff",
+        "background-opacity": 0.6
+      },
+      "layout": {
+        "visibility": "visible"
+      }
+    },
+    {
       "id": "water_line",
       "type": "line",
       "source": "base_v1.0.0",


### PR DESCRIPTION
Adds a background-type layer above the swissimage raster and below all vector overlays in the imagery style, washing out the satellite basemap so tactical overlays keep contrast. Always on, not user-controllable.

Closes #1588