### PR TITLE
feat(ui): make role-based access control for incidents generally available

### DIFF
--- a/ui/features.yaml
+++ b/ui/features.yaml
@@ -31,16 +31,6 @@ flags:
       - segment:
           key: SitrepManaged
           value: true
-  # nimdanitro: flag for rolling out the RBAC editors (incident access panel, admin), remove after RBAC is GA
-  - key: show-rbac-editors
-    name: Show RBAC editors
-    type: BOOLEAN_FLAG_TYPE
-    description: Show the incident access panel and the admin group/user management UI
-    enabled: false
-    rollouts:
-      - segment:
-          key: Development
-          value: true
 segments:
   - key: Development
     name: Development

--- a/ui/src/components/Navbar.tsx
+++ b/ui/src/components/Navbar.tsx
@@ -56,7 +56,10 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
         <NavLink
           to="/"
           className={({ isActive }) =>
-            clsx("flex shrink-0 items-center px-3", isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")
+            clsx(
+              "flex shrink-0 items-center px-3",
+              isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+            )
           }
         >
           <img src={logo} alt="Logo" className="h-6 w-auto" />
@@ -160,21 +163,36 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
         >
           {/* Incident */}
           <NavLink
-            className={({ isActive }) => clsx(mobileItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")}
+            className={({ isActive }) =>
+              clsx(
+                mobileItem,
+                isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+              )
+            }
             to={incidentId ? `/incident/${incidentId}/edit` : "/"}
           >
             <FontAwesomeIcon icon={faExplosion} />
             <span>{t("incident")}</span>
           </NavLink>
           <NavLink
-            className={({ isActive }) => clsx(mobileSubItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")}
+            className={({ isActive }) =>
+              clsx(
+                mobileSubItem,
+                isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+              )
+            }
             to="/incident/list"
           >
             <FontAwesomeIcon icon={faRectangleList} />
             <span>{t("overview")}</span>
           </NavLink>
           <NavLink
-            className={({ isActive }) => clsx(mobileSubItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")}
+            className={({ isActive }) =>
+              clsx(
+                mobileSubItem,
+                isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+              )
+            }
             to="/incident/new"
           >
             <FontAwesomeIcon icon={faCirclePlus} />
@@ -183,7 +201,10 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
           {incidentState.incident && (
             <NavLink
               className={({ isActive }) =>
-                clsx(mobileSubItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")
+                clsx(
+                  mobileSubItem,
+                  isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+                )
               }
               to={`/incident/${incidentId}/edit`}
             >
@@ -195,7 +216,12 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
           {incidentId && (
             <>
               <NavLink
-                className={({ isActive }) => clsx(mobileItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")}
+                className={({ isActive }) =>
+                  clsx(
+                    mobileItem,
+                    isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+                  )
+                }
                 to={`/incident/${incidentId}/journal/messages`}
               >
                 <FontAwesomeIcon icon={faBars} />
@@ -203,7 +229,10 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
               </NavLink>
               <NavLink
                 className={({ isActive }) =>
-                  clsx(mobileSubItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")
+                  clsx(
+                    mobileSubItem,
+                    isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+                  )
                 }
                 to={`/incident/${incidentId}/journal/messages`}
               >
@@ -212,7 +241,10 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
               </NavLink>
               <NavLink
                 className={({ isActive }) =>
-                  clsx(mobileSubItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")
+                  clsx(
+                    mobileSubItem,
+                    isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+                  )
                 }
                 to={`/incident/${incidentId}/journal/edit`}
               >
@@ -224,7 +256,12 @@ const Navbar: FunctionComponent<{ isActive?: boolean }> = ({ isActive = false })
           {/* Map */}
           {incidentId && (
             <NavLink
-              className={({ isActive }) => clsx(mobileItem, isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle")}
+              className={({ isActive }) =>
+                clsx(
+                  mobileItem,
+                  isActive ? "bg-primary text-white! hover:bg-primary" : "hover:bg-bg-subtle",
+                )
+              }
               to={`/incident/${incidentId}/map`}
             >
               <FontAwesomeIcon icon={faMapLocationDot} />
@@ -294,12 +331,8 @@ function VersionNavBar() {
 function UserNavBar() {
   const { state: userState } = useContext(UserContext);
   const { t } = useTranslation();
-  const showRbacEditors = useBooleanFlagValue("show-rbac-editors", false);
-  const myRolesResult = useMyGlobalRoles(!showRbacEditors || !userState.isLoggedin);
-  const isAdmin =
-    showRbacEditors &&
-    myRolesResult.status === "ready" &&
-    (myRolesResult.data?.grants ?? []).length > 0;
+  const myRolesResult = useMyGlobalRoles(!userState.isLoggedin);
+  const isAdmin = myRolesResult.status === "ready" && (myRolesResult.data?.grants ?? []).length > 0;
 
   if (!userState.isLoggedin) return;
 

--- a/ui/src/views/incident/Editor.tsx
+++ b/ui/src/views/incident/Editor.tsx
@@ -1,6 +1,5 @@
 import { Spinner } from "components";
 import { Notification } from "components/ui";
-import { useBooleanFlagValue } from "@openfeature/react-sdk";
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router";
 import { useIncidentDetails } from "api";
@@ -10,7 +9,6 @@ import { IncidentForm } from "./New";
 function Editor() {
   const { incidentId } = useParams();
   const { t } = useTranslation();
-  const showRbacEditors = useBooleanFlagValue("show-rbac-editors", false);
 
   const result = useIncidentDetails(incidentId);
 
@@ -26,7 +24,7 @@ function Editor() {
       <div className="mb-4 rounded border border-border bg-bg-elevated p-5 shadow-sm">
         <IncidentForm incident={result.data.incident} />
       </div>
-      {showRbacEditors && incidentId && result.data.incident.canManageAccess && (
+      {incidentId && result.data.incident.canManageAccess && (
         <IncidentAccessSection incidentId={incidentId} />
       )}
     </>


### PR DESCRIPTION
## Summary

Removes the `show-rbac-editors` feature flag and makes the RBAC editors generally available to all customers.

- Removed the `show-rbac-editors` flag definition from `features.yaml`
- `Navbar.tsx`: the admin menu entry (group/user management) is now shown whenever the current user has global admin roles, no longer gated behind the flag
- `Editor.tsx`: the incident access panel is now shown whenever the user can manage access on the incident, no longer gated behind the flag

## Test plan

- `yarn fmt` / `yarn lint` pass