### PR TITLE
feat: switch ID generation from UUIDv4 to UUIDv7

### DIFF
--- a/internal/adapter/outbound/eventstore/inmem/store.go
+++ b/internal/adapter/outbound/eventstore/inmem/store.go
@@ -226,7 +226,14 @@ func (SnapshotStore) Save(_ context.Context, _ eventsourcing.Aggregate) error { 
 
 type UUIDGen struct{}
 
-func (UUIDGen) New() uuid.UUID { return uuid.New() }
+func (UUIDGen) New() uuid.UUID {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.New()
+	}
+
+	return id
+}
 
 type WallClock struct{}
 

--- a/internal/adapter/outbound/eventstore/postgres/eventstore.go
+++ b/internal/adapter/outbound/eventstore/postgres/eventstore.go
@@ -349,10 +349,22 @@ type WallClock struct{}
 
 func (WallClock) Now() time.Time { return time.Now().UTC() }
 
-// UUIDGen implements outbound.IDs using the random UUID generator.
+// UUIDGen implements outbound.IDs using the time-ordered UUID v7 generator.
+// v7 ids sort chronologically, which reduces B-tree page splits on time-ordered
+// insertions — a meaningful benefit on SD-card-backed storage.
 type UUIDGen struct{}
 
-func (UUIDGen) New() uuid.UUID { return uuid.New() }
+func (UUIDGen) New() uuid.UUID {
+	id, err := uuid.NewV7()
+	if err != nil {
+		// NewV7 can fail only on an entropy exhaustion error that is itself
+		// extremely rare. Fall back to v4 rather than propagating the error
+		// through the outbound.IDs interface, which has no error return.
+		return uuid.New()
+	}
+
+	return id
+}
 
 // ──────────────────────────────────────────────────────────────────────────────
 // Helpers

--- a/internal/adapter/outbound/queries/inmem/access.go
+++ b/internal/adapter/outbound/queries/inmem/access.go
@@ -67,7 +67,16 @@ func (q *AccessQueries) ListAccessGroups(_ context.Context) ([]outbound.AccessGr
 		})
 	}
 
-	sort.Slice(out, func(i, j int) bool { return out[i].ID.String() < out[j].ID.String() })
+	// Sort by name then id to match the Postgres adapter's ORDER BY name, id.
+	// Previously sorted by id-only; aligning now that ids are v7 and therefore
+	// creation-ordered, which would have made the order meaningful but wrong.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+
+		return out[i].ID.String() < out[j].ID.String()
+	})
 
 	return out, nil
 }


### PR DESCRIPTION
## What

Switch both `UUIDGen` implementations (postgres and inmem adapters) from `uuid.New()` (v4) to `uuid.NewV7()` with a v4 fallback on entropy exhaustion. Also aligns `inmem.ListAccessGroups` sort order to `name, id` matching the Postgres adapter.

## Why

UUIDv7's 48-bit time prefix makes primary-key insertions append-mostly at the right edge of the B-tree index rather than scattering randomly across the page space. Under PostgreSQL this reduces index bloat and write amplification; under the upcoming SQLite backend (targeting Raspberry Pi / Rock Pi 5B) where WAL flushes hit slow SD-card storage, random-write B-tree splits dominate write latency — v7 eliminates most of them.

All persisted domain ids flow through the `outbound.IDs` port. Exactly two `UUIDGen.New()` function bodies exist; the change is contained.

## What doesn't change

- No schema changes. Existing Postgres data retains its v4 ids (immutable event-stream keys). Mixed v4/v7 data is harmless — nothing reads or validates the UUID version (`uuid.Parse` is version-agnostic, no `.Version()` checks exist anywhere in the codebase).
- Feature ids minted client-side (deterministic v3 in `ui/src/views/map/Map.tsx`) are unaffected.
- The OAuth state nonce at `server/auth/oidc.go:95` already used v7 and is unchanged.
- The `google/uuid v1.6.0` pinned in `go.mod` already provides `NewV7` — no dependency bump.

## Tests

All existing tests pass. No test asserts a UUID version or format; all `uuid.Parse` call sites are version-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)