### PR TITLE
fix(ui): align message action buttons to bottom of action bar

### DIFF
--- a/ui/src/views/journal/Message.tsx
+++ b/ui/src/views/journal/Message.tsx
@@ -295,7 +295,7 @@ const MessageContainer = ({
 
       {/* Action bar — division tags left, edit/triage buttons right */}
       {(hasDivisions || (showControls === true && id !== undefined)) && (
-        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-b pt-1.5">
+        <div className="flex flex-wrap items-end gap-x-2 gap-y-1 rounded-b pt-1.5">
           {/* Left — division tags (full-width on mobile so buttons wrap below) */}
           <div className="flex w-full flex-wrap gap-1.5 px-2 py-4 sm:w-auto sm:flex-1">
             {message.divisions?.map((d) => (


### PR DESCRIPTION
## Summary

The division tags in the message action bar have `py-4`, which made the taller row push the edit/triage/print buttons to appear vertically centered instead of bottom-aligned.

- `Message.tsx`: changed the action bar container from `items-center` to `items-end` so the buttons sit at the bottom of the row.

## Test plan

- Visual check of message cards with multiple division tags