### PR TITLE
fix(ui):  make sure the reload prompt is not below the NavBar

### DIFF
--- a/ui/src/utils/ReloadSWPrompt.tsx
+++ b/ui/src/utils/ReloadSWPrompt.tsx
@@ -221,7 +221,7 @@ export function ReloadPrompt() {
   return (
     <>
       {visible && offlineReady && (
-        <div className="px-4 pt-4">
+        <div className="mt-[2.75rem] px-4 pt-4">
           <Notification variant="success" light className="relative mt-2">
             <button
               type="button"


### PR DESCRIPTION
## Summary

The offline-ready reload toast was rendered flush against the top of the page, overlapping the fixed navbar.

- `ReloadSWPrompt.tsx`: added `mt-[2.75rem]` to the wrapping div so the toast clears the navbar.

## Test plan

- `yarn fmt` / `yarn lint` pass