### PR TITLE
fix(ui): reduce gap between Layer and Style map control buttons

### DIFF
--- a/ui/src/views/map/Map.tsx
+++ b/ui/src/views/map/Map.tsx
@@ -150,7 +150,7 @@ function Layers() {
 
   return (
     <>
-      <div className="maplibregl-ctrl-bottom-right mx-2 my-2 flex flex-col">
+      <div className="maplibregl-ctrl-bottom-right mx-2 my-2 flex flex-col gap-1">
         <LayerControl />
         <StyleController />
       </div>

--- a/ui/src/views/map/controls/LayerControl.tsx
+++ b/ui/src/views/map/controls/LayerControl.tsx
@@ -14,7 +14,7 @@ function LayerPanel() {
 
   if (!active) {
     return (
-      <div className="maplibregl-ctrl maplibregl-ctrl-group self-end text-black">
+      <div className="maplibregl-ctrl maplibregl-ctrl-group self-end text-black !mb-0">
         <button type="button" className="maplibregl-ctrl-icon" onClick={() => setActive(true)}>
           <FontAwesomeIcon icon={faLayerGroup} size="lg" />
         </button>

--- a/ui/src/views/map/controls/StyleController.tsx
+++ b/ui/src/views/map/controls/StyleController.tsx
@@ -96,7 +96,7 @@ function StyleController() {
 
   if (!active) {
     return (
-      <div className="maplibregl-ctrl maplibregl-ctrl-group self-end text-black">
+      <div className="maplibregl-ctrl maplibregl-ctrl-group self-end text-black !mb-0">
         <button type="button" className={btnClass} onClick={() => setActive(!active)}>
           <FontAwesomeIcon icon={faMap} size="lg" />
         </button>


### PR DESCRIPTION
## Summary

- MapLibre's CSS applies `margin-bottom: 10px` to every `.maplibregl-ctrl` inside a `.maplibregl-ctrl-bottom-right` container. Both the Layer and Style buttons carry that class, so the gap between them was 10 px of margin from each button stacked on top of each other.
- Added `!mb-0` to each button's root div to override the MapLibre-injected margin, and replaced it with `gap-1` (4 px) on the flex container for a compact consistent separation.

## Test plan

- [ ] Open the map view and verify the Layer and Style buttons in the bottom-right corner sit close together with a small uniform gap
- [ ] Confirm clicking each button still opens its respective panel correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)